### PR TITLE
Tradable overrides

### DIFF
--- a/config/overrides.json
+++ b/config/overrides.json
@@ -115,5 +115,11 @@
   },
   "/Lotus/Upgrades/Mods/Warframe/AvatarMissionSpecificResistanceIce": {
     "isExilus": true
+  },
+  "/Lotus/Upgrades/Mods/Warframe/Expert/VigorModExpert": {
+    "tradable": false
+  },
+  "/Lotus/Upgrades/Mods/Rifle/Event/CritChanceWhileAimingRifleMod": {
+    "tradable": true
   }
 }


### PR DESCRIPTION
User brought up that the "tradable-ness" of [`argon scope`](https://api.warframestat.us/mods/search/argon%20scope) and [`primed vigor`](https://api.warframestat.us/mods/search/primed%20vigor) were both wrong.