### PR TITLE
Fix MK1-weapons not matching wikia url

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -224,6 +224,11 @@ class Parser {
       item.isArchwing = true
     }
 
+    // Fix Mk1 weapons not matching wikia url
+    if (item.name && item.name.includes('Mk1')) {
+      item.name = item.name.replace('Mk1', 'MK1')
+    }
+
     // Relics don't have their grade in the name for some reason
     if (item.type === 'Relic') {
       const grades = require('../config/relicGrades.json')
@@ -677,6 +682,10 @@ class Parser {
       item.disposition = 4
     } else if (item.omegaAttenuation <= 1.6) {
       item.disposition = 5
+    }
+    // Re-apply correct names to MK1-weapons
+    if (item.name && item.name.includes('MK1')) {
+      item.name = item.name.replace('MK1', 'Mk1')
     }
   }
 

--- a/data/json/Melee.json
+++ b/data/json/Melee.json
@@ -62638,10 +62638,23 @@
     "omegaAttenuation": 1.29,
     "channelingDrain": 5,
     "channelingDamageMultiplier": 0.5,
-    "type": "Misc",
+    "type": "Staff",
     "imageName": "mk1-bo.png",
     "category": "Melee",
-    "tradable": false
+    "tradable": false,
+    "channeling": 1.5,
+    "damage": "45.0",
+    "damageTypes": {
+      "impact": 40.5,
+      "puncture": 4.5
+    },
+    "polarities": [ "Vazarin" ],
+    "stancePolarity": "Unairu",
+    "tags": [ "Tenno" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/7/74/BoStaff.png/revision/latest?cb=20170210002058",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Bo",
+    "disposition": 4
   },
   {
     "name": "Mk1-Furax",
@@ -62670,10 +62683,24 @@
     "omegaAttenuation": 1.38,
     "channelingDrain": 5,
     "channelingDamageMultiplier": 0.5,
-    "type": "Misc",
+    "type": "Fist",
     "imageName": "mk1-furax.png",
     "category": "Melee",
-    "tradable": false
+    "tradable": false,
+    "channeling": 1.5,
+    "damage": "30.0",
+    "damageTypes": {
+      "impact": 21,
+      "slash": 4.5,
+      "puncture": 4.5
+    },
+    "polarities": [  ],
+    "stancePolarity": "Vazarin",
+    "tags": [ "Grineer" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/2/23/Furax.png/revision/latest?cb=20130426080553",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Furax",
+    "disposition": 5
   },
   {
     "name": "Nami Skyla",

--- a/data/json/Primary.json
+++ b/data/json/Primary.json
@@ -72954,7 +72954,21 @@
     "type": "Rifle",
     "imageName": "mk1-braton.png",
     "category": "Primary",
-    "tradable": false
+    "tradable": false,
+    "ammo": 540,
+    "damage": "18.0",
+    "damageTypes": {
+      "impact": 4.5,
+      "slash": 9,
+      "puncture": 4.5
+    },
+    "polarities": [  ],
+    "projectile": "Hitscan",
+    "tags": [ "Tenno" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/1/19/Braton.png/revision/latest?cb=20170210002053",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Braton",
+    "disposition": 4
   },
   {
     "name": "Mk1-Paris",
@@ -72982,10 +72996,26 @@
     "masteryReq": 0,
     "omegaAttenuation": 1.3,
     "channelingDrain": 476048080,
-    "type": "Misc",
+    "type": "Bow",
     "imageName": "mk1-paris.png",
     "category": "Primary",
-    "tradable": false
+    "tradable": false,
+    "ammo": 72,
+    "damage": "100.0",
+    "damageTypes": {
+      "impact": 5,
+      "slash": 15,
+      "puncture": 80
+    },
+    "flight": 70,
+    "polarities": [ "Naramon" ],
+    "projectile": "Projectile",
+    "statusChance": 15,
+    "tags": [ "Tenno" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/7/7d/Paris.png/revision/latest?cb=20170210002054",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Paris",
+    "disposition": 4
   },
   {
     "name": "Mk1-Strun",
@@ -73013,10 +73043,24 @@
     "masteryReq": 0,
     "omegaAttenuation": 1.35,
     "channelingDrain": 476048080,
-    "type": "Misc",
+    "type": "Shotgun",
     "imageName": "mk1-strun.png",
     "category": "Primary",
-    "tradable": false
+    "tradable": false,
+    "ammo": 120,
+    "damage": "180.0",
+    "damageTypes": {
+      "impact": 99,
+      "slash": 54,
+      "puncture": 27
+    },
+    "polarities": [ "Naramon" ],
+    "projectile": "Hitscan",
+    "tags": [ "Tenno" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/2/26/Strun.png/revision/latest?cb=20161125225500",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Strun",
+    "disposition": 5
   },
   {
     "name": "Mutalist Cernos",

--- a/data/json/Secondary.json
+++ b/data/json/Secondary.json
@@ -60326,10 +60326,24 @@
     "masteryReq": 0,
     "omegaAttenuation": 1.35,
     "channelingDrain": 476048080,
-    "type": "Misc",
+    "type": "Pistol",
     "imageName": "mk1-furis.png",
     "category": "Secondary",
-    "tradable": false
+    "tradable": false,
+    "ammo": 210,
+    "damage": "13.0",
+    "damageTypes": {
+      "impact": 1.95,
+      "slash": 1.95,
+      "puncture": 9.1
+    },
+    "polarities": [ "Naramon" ],
+    "projectile": "Hitscan",
+    "tags": [ "Tenno" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/3/3e/Furis.png/revision/latest?cb=20170606011114",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Furis",
+    "disposition": 5
   },
   {
     "name": "Mk1-Kunai",
@@ -60357,10 +60371,25 @@
     "masteryReq": 0,
     "omegaAttenuation": 1.51,
     "channelingDrain": 476048080,
-    "type": "Misc",
+    "type": "Thrown",
     "imageName": "mk1-kunai.png",
     "category": "Secondary",
-    "tradable": false
+    "tradable": false,
+    "ammo": 210,
+    "damage": "40.0",
+    "damageTypes": {
+      "impact": 4,
+      "slash": 6,
+      "puncture": 30
+    },
+    "flight": 70,
+    "polarities": [ "Madurai", "Madurai" ],
+    "projectile": "Projectile",
+    "tags": [ "Tenno" ],
+    "vaulted": false,
+    "wikiaThumbnail": "https://vignette.wikia.nocookie.net/warframe/images/3/35/Kunai2.png/revision/latest?cb=20170210002129",
+    "wikiaUrl": "http://warframe.fandom.com/wiki/MK1-Kunai",
+    "disposition": 5
   },
   {
     "name": "Multron",


### PR DESCRIPTION
MK1-weapons have their name transformed to 'Mk1-', and wikia-url created from that name won't match in parser.addAdditionalWikiaData()