### PR TITLE
Bugfix: Add in missing chargeTime

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -666,6 +666,7 @@ class Parser {
     const damageTypes = require('../config/damageTypes.json')
     item.ammo = wikiaItem.ammo
     item.channeling = wikiaItem.channeling
+    item.chargeTime = wikiaItem.chargeTime
     item.damage = wikiaItem.damage
     item.damageTypes = {}
     damageTypes.forEach(type => {

--- a/build/wikia/transformers/transformWeapon.js
+++ b/build/wikia/transformers/transformWeapon.js
@@ -138,6 +138,7 @@ const transformWeapon = (oldWeapon, imageUrls) => {
         }
       })
     } else if (ChargeAttack && ChargeAttack.Damage) {
+      newWeapon.chargeTime = Number(Number(ChargeAttack.ChargeTime));
       damageTypes.forEach((damageType) => {
         newWeapon[damageType.toLowerCase()] = ChargeAttack.Damage[damageType] ? Number(ChargeAttack.Damage[damageType].toFixed(2).replace(/(\.[\d]+)0/, '$1')) : undefined
       })

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,6 +128,7 @@ declare module 'warframe-items' {
         masteryReq?: number;
         omegaAttenuation?: number;
         ammo?: number;
+        chargeTime?: number;
         damage?: number | string;
         damageTypes?: DamageTypes;
         flight?: number;


### PR DESCRIPTION
This is required to properly compute damage over time of continuous beam
weapons (E.g. the Phage), and charge-trigger energy weapons (e.g.
Opticor).

closes WFCD/warframe-items#126