### PR TITLE
Bugfix: Add missing areaAttack

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -665,6 +665,7 @@ class Parser {
   addWeaponWikiaData (item, wikiaItem) {
     const damageTypes = require('../config/damageTypes.json')
     item.ammo = wikiaItem.ammo
+    item.areaAttack = wikiaItem.areaAttack
     item.channeling = wikiaItem.channeling
     item.chargeTime = wikiaItem.chargeTime
     item.damage = wikiaItem.damage

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,6 +86,7 @@ declare module 'warframe-items' {
         sex?: Sex;
         sprint?: number;
         passiveDescription?: string;
+        areaAttack?: AreaAttack;
         secondary?: Secondary;
         secondaryArea?: SecondaryArea;
         statusChance?: number;
@@ -171,6 +172,19 @@ declare module 'warframe-items' {
         blast?: number;
         corrosive?: number;
         radiation?: number;
+    }
+
+    interface AreaAttack {
+        name: string;
+        status_chance?: number;
+        radius?: number;
+        blast?: number;
+        heat?: number;
+        radiation?: number;
+        damage: string;
+        pellet?: Pellet;
+        duration?: number;
+        speed?: number;
     }
 
     interface SecondaryArea {


### PR DESCRIPTION
areaAttack information missing from various weapons.  This is relevant
to all weapons with a radial damage value such as the Kulstar, Angstrum,
etc.

When looking into this information it was noticed that the damagePerShot
array includes the damage information for the radial Damage, but does
not include relevant information to help distinguish radial damage from
primary damage.  This is relevant as weapons with Radial Damage have
double-gains from all damage mods (adding Corrosion is applied to the
Primary damage and again via Radial Damage). In effect, if a weapon
supports radial damage, then the damagePerShot array is unusable for
calculating DPS of the weapon.