### PR TITLE
Fix build failure when running lint

### DIFF
--- a/build/wikia/transformers/transformWeapon.js
+++ b/build/wikia/transformers/transformWeapon.js
@@ -138,7 +138,7 @@ const transformWeapon = (oldWeapon, imageUrls) => {
         }
       })
     } else if (ChargeAttack && ChargeAttack.Damage) {
-      newWeapon.chargeTime = Number(Number(ChargeAttack.ChargeTime));
+      newWeapon.chargeTime = Number(Number(ChargeAttack.ChargeTime))
       damageTypes.forEach((damageType) => {
         newWeapon[damageType.toLowerCase()] = ChargeAttack.Damage[damageType] ? Number(ChargeAttack.Damage[damageType].toFixed(2).replace(/(\.[\d]+)0/, '$1')) : undefined
       })


### PR DESCRIPTION
Commit 4744d40f introduced a trailing semicolon that violates the build
checks performed during `npm run lint`.