### PR TITLE
fix: expose caches via the versions field

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@
  * @property {boolean} ignoreEnemies If true, don't load any enemy categories
  */
 
+const versions = require('./data/cache/.export.json')
+
 const defaultOptions = { category: ['All'] }
 
 class Items extends Array {
@@ -65,6 +67,8 @@ class Items extends Array {
         return res
       }
     })
+
+    this.versions = versions
   }
 
   /**


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
added a 'versions' field to expose the exports hashes

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter through `npm run lint`? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**
