### PR TITLE
Add lua to docker dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:alpine
 
 # Build deps
-RUN apk add --update --no-cache git openssh make gcc g++ python curl libpng-dev bash iproute2 \
+RUN apk add --update --no-cache git openssh make gcc g++ python curl libpng-dev bash iproute2 lua \
   && npm install node-gyp -g
 
 # Clone repo

--- a/docker/Dockerfile.armhf
+++ b/docker/Dockerfile.armhf
@@ -3,7 +3,7 @@ FROM resin/raspberry-pi-alpine-node
 # Build deps
 RUN apk add --update --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
     vips-dev fftw-dev libc6-compat \
-  && apk add --update --no-cache git openssh make gcc g++ python curl libpng-dev bash iproute2 \
+  && apk add --update --no-cache git openssh make gcc g++ python curl libpng-dev bash iproute2 lua \
   && npm install node-gyp -g
 
 # Clone repo


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Wikia parsing requires `lua` installed. Currently it fails with since docker image doesn't have it listed in `apk install`.

---

### Reproduction steps
1. `docker build`
2. `docker run`
3. `npm run build`

---

### Evidence/screenshot/link to line
-

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter through `npm run lint`? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
