### PR TITLE
fix(parser): Change/Add tradable conditions

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -464,7 +464,7 @@ class Parser {
   /**
    * Limit items to tradable/untradable if specified.
    */
-    addTradable (item) {
+  addTradable (item) {
     const tradableTypes = ['Arcane', 'Fish', 'Focus Lens', 'Relic', 'Rifle Mod',
       'Secondary Mod', 'Shotgun Mod', 'Warframe Mod', 'Companion Mod', 'Archwing Mod', 'K-Drive Mod',
       'Melee Mod']
@@ -479,7 +479,6 @@ class Parser {
     const isTradable = tradableByType || tradableByName || tradableByProp
     item.tradable = isTradable || false
   }
-
 
   /**
    * Add ducats for prime items. We'll need to get this data from the wikia.

--- a/build/parser.js
+++ b/build/parser.js
@@ -464,20 +464,22 @@ class Parser {
   /**
    * Limit items to tradable/untradable if specified.
    */
-  addTradable (item) {
-    const tradableTypes = ['Upgrades', 'Fish', 'Key', 'Focus Lens', 'Relic', 'Rifle Mod',
+    addTradable (item) {
+    const tradableTypes = ['Arcane', 'Fish', 'Focus Lens', 'Relic', 'Rifle Mod',
       'Secondary Mod', 'Shotgun Mod', 'Warframe Mod', 'Companion Mod', 'Archwing Mod', 'K-Drive Mod',
       'Melee Mod']
-    const untradableTypes = ['Skin', 'Medallion', 'Extractor', 'Pets', 'Ship Decoration']
-    const tradableRegex = /(Prime|Vandal|Wraith|Rakta|Synoid|Sancti|Vaykor|Telos|Secura)/i
-    const untradableRegex = /(Glyph|Mandachord|Greater.*Lens|Sugatra)/i
-    const notFiltered = !untradableTypes.includes(item.type) && !item.name.match(untradableRegex)
+    const untradableTypes = ['Skin', 'Medallion', 'Key', 'Extractor', 'Pets', 'Ship Decoration',
+      'Glyph', 'Sigil', 'Fur Color', 'Syandana', 'Fur Pattern', 'Color Palette', 'Node', 'Exalted Weapon']
+    const tradableRegex = /(Prime|Vandal|Wraith|Rakta|Synoid|Sancti|Vaykor|Telos|Secura|Ayatan|Prisma)/i
+    const untradableRegex = /(Glyph|Mandachord|Greater.*Lens|Sugatra|\[|SentinelWeapons|Toroid|Bait)/i
+    const notFiltered = !untradableTypes.includes(item.type) && !item.name.match(untradableRegex) && !item.uniqueName.match(untradableRegex) && (item.hasOwnProperty('productCategory') ? !item.productCategory.match(/(SpecialItems)/) : true)
     const tradableByType = tradableTypes.includes(item.type) && notFiltered
     const tradableByName = (item.uniqueName.match(tradableRegex) || item.name.match(tradableRegex)) && notFiltered
     const tradableByProp = (item.isAugment) && notFiltered
     const isTradable = tradableByType || tradableByName || tradableByProp
     item.tradable = isTradable || false
   }
+
 
   /**
    * Add ducats for prime items. We'll need to get this data from the wikia.


### PR DESCRIPTION
Added conditions to the tradable property assignment to match in-game tradable property

More precisely, fixed :
-> arcanes, Prisma weapons, ayatan sculptures being not tradable 
-> fur, color palettes, nodes, exalted weapons, sola toroid, quests, baits, some "[Ph]" items, some sigils, some skins being tradable

### What did you fix? (provide a description or issue closes statement)
Fixed some problems of issue \#5
---

### Reproduction steps
1. Fetched all items
2. Got only tradable items
3. Found some items with incorrect "tradable" property

---

### Evidence/screenshot/link to line

You can see my fix [on this line](#line-number-468) for where the new data exists

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter through `npm run lint`? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix + Enhancement]**
