### PR TITLE
Added ProductCategory type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ declare module 'warframe-items' {
         compatName?: string;
         isAugment?: boolean;
         transmutable?: boolean;
-        productCategory?: string;
+        productCategory?: ProductCategory;
         multishot?: number;
         blockingAngle?: number;
         comboDuration?: number;
@@ -332,6 +332,20 @@ declare module 'warframe-items' {
         value: number;
         locTag?: string;
     }
+
+    type ProductCategory =
+        'KubrowPets' |
+        'LongGuns' |
+        'MechSuits' |
+        'Melee' |
+        'Pistols' |
+        'SentinelWeapons' |
+        'Sentinels' |
+        'SpaceGuns' |
+        'SpaceMelee' |
+        'SpaceSuits' |
+        'SpecialItems' |
+        'Suits'
 
     type Aura =
         'madurai' |


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Fixed the missing ProductCategory type

---

### Reproduction steps
1. Try to run the file with typescript.

---

### Evidence/screenshot/link to line
 [ProductCategory missing](#line-number-196)
![image](https://user-images.githubusercontent.com/42449362/97690440-c0084880-1a7b-11eb-8e17-78e390077f5d.png)

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
