### PR TITLE
Better Drop names regex

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Pull Request Checks
+on: pull_request
+
+jobs:
+  lint:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: leafo/gh-actions-lua@v8.0.0
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Pull Request Checks
+name: Build
 on: pull_request
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+name: Pull Request Checks
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run:
+        - npm install
+        - npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        node-version: [11.x, 12.x, 13.x, 14.x, 15.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test
+      env:
+        CI: true

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -1,6 +1,5 @@
 name: Pull Request Checks
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   lint:
@@ -17,9 +16,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run:
-        - npm install
-        - npm run lint
+      run: npm install
+    - run: npm run lint
 
   test:
     name: Test

--- a/build/parser.js
+++ b/build/parser.js
@@ -2,6 +2,7 @@ const Progress = require('./progress.js')
 const previousBuild = require('../data/json/All.json')
 const watson = require('../config/dt_map.json')
 const bpConflicts = require('../config/bpConflicts.json')
+const variants = require('../config/variants')
 const _ = require('lodash')
 const title = (str = '') => str.toLowerCase().replace(/\b\w/g, l => l.toUpperCase())
 const warnings = {
@@ -16,6 +17,7 @@ const warnings = {
 const filterBps = (blueprint) => !bpConflicts.includes(blueprint.uniqueName)
 
 const primeExcludeRegex = /(^Noggle .*|Extractor .*|^[A-Z]{1,1} Prime$|^Excalibur .*|^Lato .*|^Skana .*)/i
+const prefixed = (name) => new RegExp(`(?:${variants.prefixes.join('|')})${name}(?:${variants.suffixes.join('|')})`)
 
 const dedupe = (arr) => Array.from(new Set(arr))
 
@@ -570,7 +572,9 @@ class Parser {
 
   findDropLocations (item, dropChances) {
     const data = dedupe(dropChances
-      .filter(drop => drop.item === item || drop.item.startsWith(item))
+      .filter(drop => drop.item === item ||
+        (drop.item.startsWith(item) && !(prefixed(item).test(drop.item)))
+      )
       .map(this.dropMap))
     data.sort(this.comparator)
     return data

--- a/config/variants.json
+++ b/config/variants.json
@@ -1,0 +1,4 @@
+{
+  "prefixes": ["Ceti", "Dex", "Kuva", "Mara", "Prisma", "Vaykor", "Telos", "Syniod", "Secura", "Rakta", "Sancti"],
+  "suffixes": ["Prime", "Vandal", "Wraith"]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ describe('index.js', function () {
     const primes = items.filter(i => i.name.includes('Prime'))
     assert(primes.length < items.length)
   })
-  
+
   describe('drops should not include variant drops', () => {
     it('should not have drops for hikou', () => {
       const Items = require('../index.js')
@@ -31,7 +31,7 @@ describe('index.js', function () {
       const { drops } = hikouMatches[0]
       assert(typeof drops === 'undefined')
     })
-    
+
     it('should only have non-prime drops for Gorgon', () => {
       const Items = require('../index.js')
       const items = new Items({ category: ['Primary'] })
@@ -39,15 +39,15 @@ describe('index.js', function () {
       assert(matches.length === 1)
       const { drops } = matches[0]
       assert(typeof drops === 'undefined')
-      
-      const bp = matches[0].components.filter(component => component.name === 'Blueprint')[0];
+
+      const bp = matches[0].components.filter(component => component.name === 'Blueprint')[0]
       assert(typeof bp !== 'undefined')
       assert(bp.drops.length !== 0)
-      
+
       const primeBpDrops = bp.drops.filter(n => n.type.includes('Prime'))
       assert(primeBpDrops.length === 0)
     })
-    
+
     it('should have variant drops when requested', () => {
       const Items = require('../index.js')
       const items = new Items({ category: ['Primary'] })
@@ -55,11 +55,11 @@ describe('index.js', function () {
       assert(matches.length === 1)
       const { drops } = matches[0]
       assert(typeof drops === 'undefined')
-      
-      const bp = matches[0].components.filter(component => component.name === 'Blueprint')[0];
+
+      const bp = matches[0].components.filter(component => component.name === 'Blueprint')[0]
       assert(typeof bp !== 'undefined')
       assert(bp.drops.length !== 0)
-      
+
       const variantDrops = bp.drops.filter(n => n.type.includes('Wraith'))
       assert(variantDrops.length === 1)
     })

--- a/test/index.js
+++ b/test/index.js
@@ -21,4 +21,47 @@ describe('index.js', function () {
     const primes = items.filter(i => i.name.includes('Prime'))
     assert(primes.length < items.length)
   })
+  
+  describe('drops should not include variant drops', () => {
+    it('should not have drops for hikou', () => {
+      const Items = require('../index.js')
+      const items = new Items({ category: ['Secondary'] })
+      const hikouMatches = items.filter(i => i.name === 'Hikou')
+      assert(hikouMatches.length === 1)
+      const { drops } = hikouMatches[0]
+      assert(typeof drops === 'undefined')
+    })
+    
+    it('should only have non-prime drops for Gorgon', () => {
+      const Items = require('../index.js')
+      const items = new Items({ category: ['Primary'] })
+      const matches = items.filter(i => i.name === 'Gorgon')
+      assert(matches.length === 1)
+      const { drops } = matches[0]
+      assert(typeof drops === 'undefined')
+      
+      const bp = matches[0].components.filter(component => component.name === 'Blueprint')[0];
+      assert(typeof bp !== 'undefined')
+      assert(bp.drops.length !== 0)
+      
+      const primeBpDrops = bp.drops.filter(n => n.type.includes('Prime'))
+      assert(primeBpDrops.length === 0)
+    })
+    
+    it('should have variant drops when requested', () => {
+      const Items = require('../index.js')
+      const items = new Items({ category: ['Primary'] })
+      const matches = items.filter(i => i.name === 'Gorgon Wraith')
+      assert(matches.length === 1)
+      const { drops } = matches[0]
+      assert(typeof drops === 'undefined')
+      
+      const bp = matches[0].components.filter(component => component.name === 'Blueprint')[0];
+      assert(typeof bp !== 'undefined')
+      assert(bp.drops.length !== 0)
+      
+      const variantDrops = bp.drops.filter(n => n.type.includes('Wraith'))
+      assert(variantDrops.length === 1)
+    })
+  })
 })


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closes #161 

---

### Reproduction steps
1. Run tests
2. Verify all of them pass

---

### Evidence/screenshot/link to line

You can see my additions [on this line](#diff-9a34d0e9ba5792f444e19c97f5890f8f95f624d306f216e54d7373a721156e40R575) for filtering drops

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
