### PR TITLE
Fix typo

### DIFF
--- a/config/variants.json
+++ b/config/variants.json
@@ -1,4 +1,4 @@
 {
-  "prefixes": ["Ceti", "Dex", "Kuva", "Mara", "Prisma", "Vaykor", "Telos", "Syniod", "Secura", "Rakta", "Sancti"],
+  "prefixes": ["Ceti", "Dex", "Kuva", "Mara", "Prisma", "Vaykor", "Telos", "Synoid", "Secura", "Rakta", "Sancti"],
   "suffixes": ["Prime", "Vandal", "Wraith"]
 }


### PR DESCRIPTION
"Syniod" should be "Synoid" unless there is something I'm missing. 