### PR TITLE
Adds falloff typings to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -243,13 +243,15 @@ declare module 'warframe-items' {
         pellet?: Pellet;
         duration?: number;
         speed?: number;
-        falloff?: {
+        falloff?: Falloff;
+    }
+    
+    interface Falloff {
             start: number;
             end: number;
             reduction: number;
-        };
     }
-
+    
     interface SecondaryArea {
         name: string;
         status_chance?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -245,13 +245,13 @@ declare module 'warframe-items' {
         speed?: number;
         falloff?: Falloff;
     }
-    
+
     interface Falloff {
             start: number;
             end: number;
             reduction: number;
     }
-    
+
     interface SecondaryArea {
         name: string;
         status_chance?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -243,6 +243,11 @@ declare module 'warframe-items' {
         pellet?: Pellet;
         duration?: number;
         speed?: number;
+        falloff?: {
+            start: number;
+            end: number;
+            reduction: number;
+        };
     }
 
     interface SecondaryArea {


### PR DESCRIPTION
Fixes issue #171, where no typescript typings were provided for Item.AreaAttack.falloff

### What did you fix? (provide a description or issue closes statement)
closed \#171

---

### Reproduction steps

Open visual studio code
Create a index.ts file
paste in the following:
```ts
import Items from 'warframe-items'
const items = new Items({ category: ['Primary'] })

let this_line_will_error = items[0].areaAttack.falloff
```
---

### Evidence/screenshot/link to line

This adds typings to the index.d.ts file, to describe the attribute Item.AreaAttack.falloff

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No, don't think so**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **Not sure**
- Have I run the linter through `npm run lint`? **No**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
