### PR TITLE
Update CI to run fully on gh actions

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,0 +1,20 @@
+name: PR Build
+on: pull_request
+
+jobs:
+  lint:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: leafo/gh-actions-lua@v8.0.0
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,5 +1,7 @@
 name: Update
 on:
+  repository_dispatch:
+    type: "trigger"
   schedule:
     - cron: "55 * * * *"
 
@@ -23,4 +25,4 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         skip_dirty_check: false
-        commit_message: 'fix(items): new items for ${{ date +%d-%b-%Y}}'
+        commit_message: 'fix(items): new items'

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,5 +1,7 @@
-name: Build
-on: pull_request
+name: Update
+on:
+  schedule:
+    - cron: "55 * * * *"
 
 jobs:
   lint:
@@ -18,3 +20,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run build
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        skip_dirty_check: false
+        commit_message: 'fix(items): new items for ${{ date +%d-%b-%Y}}'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,57 @@
+name: Release Verification
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm install
+    - run: npm run lint
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        node-version: [11.x, 12.x, 13.x, 14.x, 15.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test
+      env:
+        CI: true
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    strategy:
+      matrix:
+        node-version: [15.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        with:
+          branches: |
+            ['development']

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode
 node_modules
 tmp
+
+
+# github action installations
+.install


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
non-running ci

---

### Reproduction steps
1. Replace drone & docker with pure gh actions

---

### Evidence/screenshot/link to line

see the .github/workflows directory

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
