### PR TITLE
chore(ci): automated builds, add build into static analysis

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build
-on: pull_request
+on:
+  schedule:
+    - cron: "55 * * * *"
 
 jobs:
   lint:
@@ -17,4 +19,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+    - run: npm update
     - run: npm run build
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        skip_dirty_check: false
+        commit_message: 'fix(items): new items'

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -18,21 +18,31 @@ jobs:
     - name: Install Dependencies
       run: npm install
     - run: npm run lint
-
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: leafo/gh-actions-lua@v8.0.0
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [build, lint]
     strategy:
       matrix:
         node-version: [11.x, 12.x, 13.x, 14.x, 15.x]
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm test
-      env:
-        CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 node_modules
 tmp
+.lua
+.install/


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
stuff not automatically building

last thing i need to take a look at is passing the bot's GH_TOKEN from the secrets so it doesn't use some random one

---

### Reproduction steps
1. Let the PR build
2. Merge PR
3. Let merge commit build
4. Wait until 5 minutes before the top of the hour
5. ???
6. Success!

---

### Evidence/screenshot/link to line

You can see my changes in .gitignore and .github/workflows/build.yaml

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**
