### PR TITLE
fix(wikia): update prime urls to use non-redirect url

### DIFF
--- a/build/wikia/transformers/transformWarframe.js
+++ b/build/wikia/transformers/transformWarframe.js
@@ -64,7 +64,7 @@ const transformWarframe = async (oldFrame, imageUrls) => {
 
     newFrame = {
       name: Name,
-      url: `http://warframe.fandom.com/wiki/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
+      url: `http://warframe.fandom.com/wiki/${encodeURIComponent(Name.replace(/\s/g, '_').replace('_Prime', '/Prime'))}`,
       thumbnail: imageUrls[Image],
       auraPolarity: AuraPolarity,
       conclave: Conclave,


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
fix wikiaUrl being something that would redirect right off

---

### Reproduction steps
N/A

---

### Evidence/screenshot/link to line



### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is it a bug fix, feature request, or enhancement? **[Enhancement]**
