### PR TITLE
fix: non-prime dupe drops & weird image urls

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,0 @@
-extends: standard
-globals:
-  describe: true
-  it: true
-rules:
-  brace-style: off

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "00:00"
+    commit-message:
+      prefix: ""
+      prefix-development: "dev"
+      include: "scope"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "-"
+    rebase-strategy: "auto"
+    ignore: []

--- a/build/build.js
+++ b/build/build.js
@@ -25,9 +25,10 @@ class Build {
     }
     const parsed = parser.parse(raw)
     const data = this.applyCustomCategories(parsed.data)
-    const all = this.saveJson(data)
+    // const all =
+    this.saveJson(data)
     this.saveWarnings(parsed.warnings)
-    await this.saveImages(all, raw.manifest)
+    // await this.saveImages(all, raw.manifest)
     this.updateReadme(raw.patchlogs.patchlogs)
 
     // Log number of warnings at the end of the script

--- a/build/dedupe.js
+++ b/build/dedupe.js
@@ -1,3 +1,5 @@
+const objectsort = require('./objectsort')
+
 /**
  * Simple deduplication leveraging reduce (and equality based on stringification)
  * @param  {*} iter Should be an iterable object, but function will check first.
@@ -6,7 +8,7 @@
 module.exports = (iter) => {
   return Array.isArray(iter)
     ? iter
-      .reduce((acc, curr) => ((!acc.includes(JSON.stringify(curr)) && acc.push(JSON.stringify(curr)) && acc) || acc), [])
+      .reduce((acc, curr) => ((!acc.includes(JSON.stringify(objectsort(curr))) && acc.push(JSON.stringify(objectsort(curr))) && acc) || acc), [])
       .map(o => JSON.parse(o))
     : iter
 }

--- a/build/objectsort.js
+++ b/build/objectsort.js
@@ -1,0 +1,10 @@
+'use strict'
+// Sorting objects by keys
+// https://www.w3docs.com/snippets/javascript/how-to-sort-javascript-object-by-key.html
+// eslint-disable-next-line no-return-assign, no-sequences
+module.exports = (obj) => {
+  return Object.keys(obj).sort().reduce(function (result, key) {
+    result[key] = obj[key]
+    return result
+  }, {})
+}

--- a/build/parser.js
+++ b/build/parser.js
@@ -672,6 +672,7 @@ class Parser {
 
     item.wikiaThumbnail = wikiaItem.thumbnail
     item.wikiaUrl = wikiaItem.url
+    this.introduced = wikiaItem.introduced
 
     if (item.omegaAttenuation <= 0.75) {
       item.disposition = 1

--- a/build/stringify.js
+++ b/build/stringify.js
@@ -1,4 +1,5 @@
-const dedupe = require('./dedupe.js')
+const dedupe = require('./dedupe')
+// const objectsort = require('./objectsort')
 
 /**
  * Pretty print JSON as it should be.
@@ -7,7 +8,7 @@ const dedupe = require('./dedupe.js')
 const isPrimitive = obj => obj === null || [ 'string', 'number', 'boolean' ].includes(typeof obj)
 const isArrayOfPrimitive = obj => Array.isArray(obj) && obj.every(isPrimitive)
 const format = arr => `^^^[ ${arr.map(val => JSON.stringify(val)).join(', ')} ]`
-const replacer = (key, value) => isArrayOfPrimitive(value) ? format(value) : value
+const replacer = (key, value) => isArrayOfPrimitive(value) ? format(value) : value // objectsort(value)
 const expand = str => str.replace(/(?:"\^\^\^)(\[ .* \])(?:")/g, (match, a) => a.replace(/\\"/g, '"'))
 const stringify = obj => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, 2))
 

--- a/build/wikia/WikiaDataScraper.js
+++ b/build/wikia/WikiaDataScraper.js
@@ -141,14 +141,13 @@ class WikiaDataScraper {
     let things = []
 
     try {
-      const keys = Object.keys(jsonData[`${this.luaObjectName}s`])
-
-      await Promise.all(await keys.map(async thingName => {
+      for (const thingName of Object.keys(jsonData[`${this.luaObjectName}s`])) {
         const thingToTransform = jsonData[`${this.luaObjectName}s`][thingName]
         if (thingToTransform && !thingToTransform.Name) thingToTransform.Name = thingName
         const transformedThing = await this.transformFunction(thingToTransform, imageUrls)
         things.push(transformedThing)
-      }))
+      }
+
       things.sort(nameCompare)
     } catch (e) {
       console.error(e.stack)

--- a/build/wikia/transformers/transformWeapon.js
+++ b/build/wikia/transformers/transformWeapon.js
@@ -61,7 +61,8 @@ const transformWeapon = (oldWeapon, imageUrls) => {
       SecondaryAttack,
       SecondaryAreaAttack,
       Traits,
-      AreaAttack
+      AreaAttack,
+      Introduced
     } = oldWeapon
 
     const { Name } = oldWeapon
@@ -76,7 +77,7 @@ const transformWeapon = (oldWeapon, imageUrls) => {
       ...(ChargeAttack && ChargeAttack.StatusChance) &&
         { status_chance: Number((Number(ChargeAttack.StatusChance) * 100).toFixed(2)) },
       polarities: Polarities,
-      thumbnail: imageUrls[Image],
+      thumbnail: imageUrls[Image] || imageUrls[Image.replace(/_/g, ' ')],
       ...MaxAmmo && { ammo: MaxAmmo },
       ...(NormalAttack && NormalAttack.ShotType) &&
         { projectile: NormalAttack.ShotType.replace(/Hit-scan/ig, 'Hitscan') },
@@ -84,6 +85,7 @@ const transformWeapon = (oldWeapon, imageUrls) => {
         { projectile: ChargeAttack.ShotType.replace(/Hit-scan/ig, 'Hitscan') },
       tags: Traits || [],
       vaulted: (Traits || []).includes('Vaulted'),
+      introduced: Introduced,
       marketCost: Cost && Cost.MarketCost,
       bpCost: Cost && Cost.BPCost,
       pellet: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "warframe-items",
   "version": "0.0.0-development",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
@@ -14497,15 +14497,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -14534,6 +14525,15 @@
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,17 @@
     "sharp": "^0.25.2",
     "socks5-http-client": "^1.0.4",
     "warframe-patchlogs": "^1.578.0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "standard"
+    ],
+    "globals": {
+      "describe": "readonly",
+      "it": "readonly"
+    },
+    "rules": {
+      "brace-style": 0
+    }
   }
 }


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closes #186 
closes #188

- check better if the item is wrapped by accepted prefixes/suffixes and exclude those
- check if it's "lightly wrapped" by anything else
- move eslint config into package.json
- new objectsort (will enable if first build goes well)
- use correct dedupe
- dependabot.yml

---

### Reproduction steps
1. Build it (`npm run build`)
2. check if items have about the right drops.
// they won't always be perfect, but closer is better than the bloat that is in right now

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
