### PR TITLE
Added new Tenet Hounds to the itemtypes

### DIFF
--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -113,6 +113,9 @@
   "id": "/Pets/CreaturePets",
   "name": "Pets"
 }, {
+  "id": "/ZanukaPetPartHead",
+  "name": "Pets"
+}, {
   "id": "/Mods/Hoverboard",
   "name": "K-Drive Mod"
 }, {


### PR DESCRIPTION
Just a small change to the itemTypes.json to consider the new Tenet Hounds, so they are available in the pets.json.
---
### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
