### PR TITLE
Fix Arch-Melee and NecraMech mods incorrectly being flaged as not tradable.

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -486,7 +486,7 @@ class Parser {
   addTradable (item) {
     const tradableTypes = ['Upgrades', 'Arcane', 'Fish', 'Focus Lens', 'Relic', 'Rifle Mod',
       'Secondary Mod', 'Shotgun Mod', 'Warframe Mod', 'Companion Mod', 'Archwing Mod', 'K-Drive Mod',
-      'Melee Mod']
+      'Melee Mod', 'Arch-Melee Mod']
     const untradableTypes = ['Skin', 'Medallion', 'Key', 'Extractor', 'Pets', 'Ship Decoration',
       'Glyph', 'Sigil', 'Fur Color', 'Syandana', 'Fur Pattern', 'Color Palette', 'Node', 'Exalted Weapon']
     const tradableRegex = /(Prime|Vandal|Wraith|Rakta|Synoid|Sancti|Vaykor|Telos|Secura|Ayatan|Prisma)/i

--- a/build/parser.js
+++ b/build/parser.js
@@ -486,7 +486,7 @@ class Parser {
   addTradable (item) {
     const tradableTypes = ['Upgrades', 'Arcane', 'Fish', 'Focus Lens', 'Relic', 'Rifle Mod',
       'Secondary Mod', 'Shotgun Mod', 'Warframe Mod', 'Companion Mod', 'Archwing Mod', 'K-Drive Mod',
-      'Melee Mod', 'Arch-Melee Mod', 'NecraMech Mod']
+      'Melee Mod', 'Arch-Melee Mod', 'Necramech Mod']
     const untradableTypes = ['Skin', 'Medallion', 'Key', 'Extractor', 'Pets', 'Ship Decoration',
       'Glyph', 'Sigil', 'Fur Color', 'Syandana', 'Fur Pattern', 'Color Palette', 'Node', 'Exalted Weapon']
     const tradableRegex = /(Prime|Vandal|Wraith|Rakta|Synoid|Sancti|Vaykor|Telos|Secura|Ayatan|Prisma)/i

--- a/build/parser.js
+++ b/build/parser.js
@@ -486,7 +486,7 @@ class Parser {
   addTradable (item) {
     const tradableTypes = ['Upgrades', 'Arcane', 'Fish', 'Focus Lens', 'Relic', 'Rifle Mod',
       'Secondary Mod', 'Shotgun Mod', 'Warframe Mod', 'Companion Mod', 'Archwing Mod', 'K-Drive Mod',
-      'Melee Mod', 'Arch-Melee Mod']
+      'Melee Mod', 'Arch-Melee Mod', 'NecraMech Mod']
     const untradableTypes = ['Skin', 'Medallion', 'Key', 'Extractor', 'Pets', 'Ship Decoration',
       'Glyph', 'Sigil', 'Fur Color', 'Syandana', 'Fur Pattern', 'Color Palette', 'Node', 'Exalted Weapon']
     const tradableRegex = /(Prime|Vandal|Wraith|Rakta|Synoid|Sancti|Vaykor|Telos|Secura|Ayatan|Prisma)/i

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -406,4 +406,7 @@
 }, {
   "id": "Customization",
   "name": "Skin"
+}, {
+  "id": "/Mods/Necromech",
+  "name": "NecraMech Mod"
 }]

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -1,7 +1,7 @@
 [{
   "id": "/Archwing/Primary",
   "name": "Arch-Gun"
-},{
+}, {
   "id": "/Mods/Archwing/Melee",
   "name": "Arch-Melee Mod"
 }, {

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -408,5 +408,5 @@
   "name": "Skin"
 }, {
   "id": "/Mods/Necromech",
-  "name": "NecraMech Mod"
+  "name": "Necramech Mod"
 }]

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -1,6 +1,9 @@
 [{
   "id": "/Archwing/Primary",
   "name": "Arch-Gun"
+},{
+  "id": "/Mods/Archwing/Melee",
+  "name": "Arch-Melee Mod"
 }, {
   "id": "/Archwing/Melee",
   "name": "Arch-Melee"


### PR DESCRIPTION
### What did you fix? 
Added Arch-Melee Mod and NecraMech Mod to tradableTypes.

---

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
