### PR TITLE
fix: exclude set mods from prefix checks

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -556,10 +556,7 @@ class Parser {
             component.drops = saved.drops
           }
         }
-      }
-
-      // Otherwise attach to main item
-      else {
+      } else { // Otherwise attach to main item
         const saved = previousBuild.find(i => i.name === item.name)
         if (saved && saved.drops) {
           // chances were written as strings, caused by previous bad data

--- a/config/variants.json
+++ b/config/variants.json
@@ -1,4 +1,36 @@
 {
-  "prefixes": ["Ceti", "Dex", "Kuva", "Mara", "Prisma", "Vaykor", "Telos", "Synoid", "Secura", "Rakta", "Sancti"],
-  "suffixes": ["Prime", "Vandal", "Wraith"]
+  "prefixes": [
+    "Ceti",
+    "Dex",
+    "Kuva",
+    "Mara",
+    "Prisma",
+    "Vaykor",
+    "Telos",
+    "Synoid",
+    "Secura",
+    "Rakta",
+    "Sancti",
+    "Augur",
+    "Gladiator",
+    "Vigilante",
+    "Hunter",
+    "Umbral",
+    "Sacrificial",
+    "Tek",
+    "Synth",
+    "Mecha",
+    "Strain",
+    "Aero",
+    "Motus",
+    "Proton",
+    "Carnis",
+    "Jugulum",
+    "Saxum"
+  ],
+  "suffixes": [
+    "Prime",
+    "Vandal",
+    "Wraith"
+  ]
 }


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closes #281 

---

### Reproduction steps
1. Added mod sets as variants

---

### Evidence/screenshot/link to line

Added mod sets as variants

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
