### PR TITLE
perf: trim package size

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,8 +2,12 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'build/**'
   pull_request:
     branches: [ master ]
+    paths:
+      - 'build/**'
   schedule:
     - cron: '25 10 * * 1'
 jobs:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: data/json
-        key: ${{ runner.os }}-${{ github.run.id }}${{ github.run.number }}
+        key: ${{ runner.os }}-${{ github.run_id }}${{ github.run_number }}
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -27,6 +27,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: leafo/gh-actions-lua@v8.0.0
+    - uses: actions/cache@v2
+      with:
+        path: data/json
+        key: ${{ runner.os }}-{{ github.run.id }}{{ github.run.number }}
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
@@ -42,6 +46,10 @@ jobs:
         node-version: [11.x, 12.x, 13.x, 14.x, 15.x]
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: data/json
+        key: ${{ runner.os }}-{{ github.run.id }}{{ github.run.number }}
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         node-version: [15.x]
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -21,6 +20,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: [ lint ]
     strategy:
       matrix:
         node-version: [15.x]
@@ -36,7 +36,24 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run build
-    - run: npm run typings
+  types:
+    name: Type Checks
+    runs-on: ubuntu-latest
+    needs: [ build, lint ]
+    strategy:
+      matrix:
+        node-version: [ 15.x ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: data/json
+          key: ${{ runner.os }}-${{ github.run_id }}${{ github.run_number }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run typings
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -49,7 +66,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: data/json
-        key: ${{ runner.os }}-${{ github.run.id }}${{ github.run.number }}
+        key: ${{ runner.os }}-${{ github.run_id }}${{ github.run_number }}
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: data/json
-        key: ${{ runner.os }}-{{ github.run.id }}{{ github.run.number }}
+        key: ${{ runner.os }}-${{ github.run.id }}${{ github.run.number }}
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: data/json
-        key: ${{ runner.os }}-{{ github.run.id }}{{ github.run.number }}
+        key: ${{ runner.os }}-${{ github.run.id }}${{ github.run.number }}
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}

--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,4 @@ coverage/
 data/cache/.images.json
 data/warnings.json
 .idea/
+data/json/All.json

--- a/build/build.js
+++ b/build/build.js
@@ -105,7 +105,7 @@ class Build {
 
     // All.json (all items in one file)
     all.sort(sort)
-    fs.writeFileSync(path.join(__dirname, '../data/json/All.json'), stringify(all))
+    fs.writeFileSync(path.join(__dirname, '../data/json/All.json'), stringify(all, 2))
     fs.writeFileSync(path.join(__dirname, '../data/json/i18n.json'), stringify(i18n))
 
     return all

--- a/build/build.js
+++ b/build/build.js
@@ -100,12 +100,12 @@ class Build {
     for (const category in categories) {
       const data = categories[category].sort(sort)
       all = all.concat(data)
-      fs.writeFileSync(path.join(__dirname, `../data/json/${category}.json`), JSON.stringify(JSON.parse(stringify(data))))
+      fs.writeFileSync(path.join(__dirname, `../data/json/${category}.json`), stringify(data))
     }
 
     // All.json (all items in one file)
     all.sort(sort)
-    fs.writeFileSync(path.join(__dirname, '../data/json/All.json'), stringify(all))
+    fs.writeFileSync(path.join(__dirname, '../data/json/All.json'), stringify(all, 2))
     fs.writeFileSync(path.join(__dirname, '../data/json/i18n.json'), stringify(i18n))
 
     return all

--- a/build/build.js
+++ b/build/build.js
@@ -100,12 +100,12 @@ class Build {
     for (const category in categories) {
       const data = categories[category].sort(sort)
       all = all.concat(data)
-      fs.writeFileSync(path.join(__dirname, `../data/json/${category}.json`), stringify(data))
+      fs.writeFileSync(path.join(__dirname, `../data/json/${category}.json`), JSON.stringify(JSON.parse(stringify(data))))
     }
 
     // All.json (all items in one file)
     all.sort(sort)
-    fs.writeFileSync(path.join(__dirname, '../data/json/All.json'), stringify(all, 2))
+    fs.writeFileSync(path.join(__dirname, '../data/json/All.json'), stringify(all))
     fs.writeFileSync(path.join(__dirname, '../data/json/i18n.json'), stringify(i18n))
 
     return all

--- a/build/stringify.js
+++ b/build/stringify.js
@@ -10,6 +10,6 @@ const isArrayOfPrimitive = obj => Array.isArray(obj) && obj.every(isPrimitive)
 const format = arr => `^^^[ ${arr.map(val => JSON.stringify(val)).join(', ')} ]`
 const replacer = (key, value) => isArrayOfPrimitive(value) ? format(value) : value // objectsort(value)
 const expand = str => str.replace(/"\^\^\^(\[ .* ])"/g, (match, a) => a.replace(/\\"/g, '"')).replace(/\\\\"/g, "'")
-const stringify = (obj) => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, 2))
+const stringify = (obj, spaces) => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, spaces || 0))
 
 module.exports = stringify

--- a/build/stringify.js
+++ b/build/stringify.js
@@ -9,7 +9,7 @@ const isPrimitive = obj => obj === null || ['string', 'number', 'boolean'].inclu
 const isArrayOfPrimitive = obj => Array.isArray(obj) && obj.every(isPrimitive)
 const format = arr => `^^^[ ${arr.map(val => JSON.stringify(val)).join(', ')} ]`
 const replacer = (key, value) => isArrayOfPrimitive(value) ? format(value) : value // objectsort(value)
-const expand = str => str.replace(/"\^\^\^(\[ .* \])"/g, (match, a) => a.replace(/\\"/g, '"')).replace(/\\\\"/g, "'")
-const stringify = obj => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, 2))
+const expand = str => str.replace(/"\^\^\^(\[ .* ])"/g, (match, a) => a.replace(/\\"/g, '"')).replace(/\\\\"/g, "'")
+const stringify = obj => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, 0))
 
 module.exports = stringify

--- a/build/stringify.js
+++ b/build/stringify.js
@@ -10,6 +10,6 @@ const isArrayOfPrimitive = obj => Array.isArray(obj) && obj.every(isPrimitive)
 const format = arr => `^^^[ ${arr.map(val => JSON.stringify(val)).join(', ')} ]`
 const replacer = (key, value) => isArrayOfPrimitive(value) ? format(value) : value // objectsort(value)
 const expand = str => str.replace(/"\^\^\^(\[ .* ])"/g, (match, a) => a.replace(/\\"/g, '"')).replace(/\\\\"/g, "'")
-const stringify = (obj, spaces) => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, spaces || 0))
+const stringify = (obj) => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, 2))
 
 module.exports = stringify

--- a/build/stringify.js
+++ b/build/stringify.js
@@ -10,6 +10,6 @@ const isArrayOfPrimitive = obj => Array.isArray(obj) && obj.every(isPrimitive)
 const format = arr => `^^^[ ${arr.map(val => JSON.stringify(val)).join(', ')} ]`
 const replacer = (key, value) => isArrayOfPrimitive(value) ? format(value) : value // objectsort(value)
 const expand = str => str.replace(/"\^\^\^(\[ .* ])"/g, (match, a) => a.replace(/\\"/g, '"')).replace(/\\\\"/g, "'")
-const stringify = obj => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, 0))
+const stringify = (obj, spaces) => expand(JSON.stringify(Array.isArray(obj) ? dedupe(obj) : obj, replacer, spaces || 0))
 
 module.exports = stringify

--- a/index.js
+++ b/index.js
@@ -32,14 +32,25 @@
  * @property {boolean} i18nOnObject Whether or not to include i18n on the object itself and not on the "array"
  */
 
+const path = require('path')
+const fs = require('fs')
 const versions = require('./data/cache/.export.json')
+
 let i18n = {}
 try {
   i18n = require('./data/json/i18n.json')
 } catch (ignored) {
   // can only happen in really weird stuff, and we're already defaulting, so it's ok
 }
-const defaultOptions = { category: ['All'], i18n: false, i18nOnObject: false }
+
+const raw = fs.readdirSync(path.join(__dirname, './data/json/'))
+const ignored = ['All', 'i18n']
+const all = raw
+  .filter(f => f.includes('.json'))
+  .map(f => f.replace('.json', ''))
+  .filter(f => !ignored.includes(f))
+
+const defaultOptions = { category: all, i18n: false, i18nOnObject: false }
 
 class Items extends Array {
   constructor (options, ...items) {
@@ -49,6 +60,13 @@ class Items extends Array {
     this.options = {
       ...defaultOptions,
       ...options
+    }
+
+    const containedAll = this.options.category.includes('All')
+    if (containedAll) {
+      this.options.category = Array.from(new Set(
+        this.options.category.filter(c => c !== 'All').concat(all)
+      ))
     }
 
     this.i18n = {}

--- a/index.js
+++ b/index.js
@@ -43,14 +43,13 @@ try {
   // can only happen in really weird stuff, and we're already defaulting, so it's ok
 }
 
-const raw = fs.readdirSync(path.join(__dirname, './data/json/'))
 const ignored = ['All', 'i18n']
-const all = raw
+const defaultCategories = fs.readdirSync(path.join(__dirname, './data/json/'))
   .filter(f => f.includes('.json'))
   .map(f => f.replace('.json', ''))
   .filter(f => !ignored.includes(f))
 
-const defaultOptions = { category: all, i18n: false, i18nOnObject: false }
+const defaultOptions = { category: defaultCategories, i18n: false, i18nOnObject: false }
 
 class Items extends Array {
   constructor (options, ...items) {
@@ -65,7 +64,7 @@ class Items extends Array {
     const containedAll = this.options.category.includes('All')
     if (containedAll) {
       this.options.category = Array.from(new Set(
-        this.options.category.filter(c => c !== 'All').concat(all)
+        this.options.category.filter(c => c !== 'All').concat(defaultCategories)
       ))
     }
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "describe": "readonly",
       "it": "readonly",
       "beforeEach": "readonly",
-      "afterEach": "readonly"
+      "afterEach": "readonly",
+      "after": "readonly"
     },
     "rules": {
       "brace-style": 0


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
start changes for #276 

---

### Reproduction steps
1. remove All.json from package (saves ~33MB)
2. Generate array of all categories on init (minus `All` and `i18n`)
2. Remove `['All']` as the default for category and replace with an array of all categories
3. Dedupe category array so we don't dupe items in "this"
4. Minify all but All.json
5. Persist build data across ci jobs

---

### Evidence/screenshot/link to line

You can see my changes in `index.js` and test in `test/index.js`

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature/Maintenance]**
