### PR TITLE
fix: check for raw i18n data before iterating

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,11 +80,14 @@ class Items extends Array {
           // only insert i18n for the objects we're inserting so we don't bloat memory
           if (Array.isArray(this.options.i18n)) {
             const raw = i18n[item.uniqueName]
-            Object.keys(raw).forEach(locale => {
-              if (!this.options.i18n.includes(locale)) {
-                delete raw[locale]
-              }
-            })
+            // only process if passed language is a supported i18n value
+            if (raw) {
+              Object.keys(raw).forEach(locale => {
+                if (!this.options.i18n.includes(locale)) {
+                  delete raw[locale]
+                }
+              })
+            }
             this.i18n[item.uniqueName] = raw
           } else {
             this.i18n[item.uniqueName] = i18n[item.uniqueName]

--- a/test/index.js
+++ b/test/index.js
@@ -40,9 +40,9 @@ describe('index.js', () => {
     const items = wrapConstr({ category: ['Primary', 'All'] })
     assert(items.length > 0)
   })
-  it('should not error with no category defined alongside other options', () => {
+  it('should not error current worldstate-data supported locales', () => {
     try {
-      wrapConstr({ i18n: true, i18nOnObject: true })
+      wrapConstr({ i18n: ['de', 'es', 'fr', 'it', 'ko', 'pl', 'pt', 'ru', 'zh', 'cs', 'sr'], i18nOnObject: true })
     } catch (e) {
       assert(typeof e === 'undefined')
     }

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,13 @@ describe('index.js', () => {
     const items = wrapConstr({ category: ['Primary', 'All'] })
     assert(items.length > 0)
   })
+  it('should not error with no category defined alongside other options', () => {
+    try {
+      wrapConstr({ i18n: true, i18nOnObject: true })
+    } catch (e) {
+      assert(typeof e === 'undefined')
+    }
+  })
 
   // Custom filter override in index.js
   it('should not return more or equal the number of objects after .filter(), when custom categories are specified.', () => {


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Add test for what seems to be a failing call in warframe-status

---

### Reproduction steps

---

### Evidence/screenshot/link to line


### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
