### PR TITLE
feat: add market costs

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -202,7 +202,7 @@ class Build {
         })
       } catch (e) {
         // swallow error
-        console.error(e)
+        // console.error(e)
       }
     }
   }

--- a/build/parser.js
+++ b/build/parser.js
@@ -698,6 +698,8 @@ class Parser {
     item.conclave = wikiaItem.conclave
     item.color = wikiaItem.color
     item.introduced = wikiaItem.introduced
+    item.marketCost = wikiaItem.marketCost
+    item.bpCost = wikiaItem.bpCost
     item.masteryReq = item.masteryReq || wikiaItem.mr
     item.polarities = wikiaItem.polarities
     item.sex = wikiaItem.sex
@@ -712,6 +714,7 @@ class Parser {
     item.attacks = wikiaItem.attacks
     item.ammo = wikiaItem.ammo
     item.marketCost = wikiaItem.marketCost
+    item.bpCost = wikiaItem.bpCost
     item.masteryReq = item.masteryReq || wikiaItem.mr
     item.polarities = wikiaItem.polarities
     item.tags = wikiaItem.tags

--- a/build/wikia/transformers/transformWarframe.js
+++ b/build/wikia/transformers/transformWarframe.js
@@ -21,7 +21,7 @@ const mapColors = async (oldFrame, imageUrl) => {
   }
 }
 
-module.exports = async (oldFrame, imageUrls) => {
+module.exports = async (oldFrame, imageUrls, blueprints) => {
   let newFrame
   if (!oldFrame || !oldFrame.Name) {
     return undefined
@@ -53,7 +53,9 @@ module.exports = async (oldFrame, imageUrls) => {
       sex: Sex,
       vaulted: Vaulted || undefined,
       thumbnail: imageUrls[Image],
-      color: parseInt(await mapColors(oldFrame, imageUrls[Image]), 16)
+      color: parseInt(await mapColors(oldFrame, imageUrls[Image]), 16),
+      marketCost: blueprints[Name] && blueprints[Name].MarketCost,
+      bpCost: blueprints[Name] && blueprints[Name].BPCost
     }
     newFrame = transformPolarity(oldFrame, newFrame)
   } catch (error) {

--- a/build/wikia/transformers/transformWeapon.js
+++ b/build/wikia/transformers/transformWeapon.js
@@ -82,7 +82,7 @@ const parseSlam = ({ SlamAttack, SlamRadialDmg, SlamRadialElement, SlamRadialPro
   }
 }
 
-module.exports = (oldWeapon, imageUrls) => {
+module.exports = (oldWeapon, imageUrls, blueprints) => {
   let newWeapon
   if (!oldWeapon || !oldWeapon.Name) {
     return undefined
@@ -92,7 +92,6 @@ module.exports = (oldWeapon, imageUrls) => {
       Mastery,
       Type,
       Class,
-      Cost,
       NormalAttack,
       MaxAmmo,
       Disposition,
@@ -140,8 +139,8 @@ module.exports = (oldWeapon, imageUrls) => {
       tags: Traits || [],
       vaulted: (Traits || []).includes('Vaulted'),
       introduced: Introduced,
-      marketCost: Cost && Cost.MarketCost,
-      bpCost: Cost && Cost.BPCost,
+      marketCost: blueprints[Name] && blueprints[Name].MarketCost,
+      bpCost: blueprints[Name] && blueprints[Name].BPCost,
       thumbnail: imageUrls[Image] || imageUrls[Image.replace(/_/g, ' ')],
       attacks: [
         NormalAttack && parseAttack(NormalAttack),

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,7 @@ declare module 'warframe-items' {
         damage?: number | string;
         damageTypes?: DamageTypes;
         marketCost?: number | '';
+        bpCost?: number | '';
         flight?: number | '???';
         polarities?: Polarity[];
         projectile?: Projectile;
@@ -184,7 +185,8 @@ declare module 'warframe-items' {
         damage?: number | string;
         damageTypes?: DamageTypes;
         flight?: number;
-        marketCost?: number;
+        marketCost?: number | '';
+        bpCost?: number | '';
         polarities?: Polarity[];
         stancePolarity?: Polarity;
         projectile?: Projectile;


### PR DESCRIPTION
### What did you fix?
parse blueprints for market costs

---

### Reproduction steps
1. add blueprints fetch before starting services

TODO:
- [x] add costs to weapon/wf data

---

### Evidence/screenshot/link to line

see transformers

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter through `npm run lint`? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
