### PR TITLE
feat: add `isPrime` flag

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -695,7 +695,7 @@ class Parser {
           (component.uniqueName.includes('/Weapons/') &&
             !component.uniqueName.includes('/WeaponParts/') &&
             component.name !== 'Blueprint') ||
-            /Collar\w+Component/.test(component.uniqueName)
+          /Collar\w+Component/.test(component.uniqueName)
             ? this.findDropLocations(component.name, drops.rates, true)
             : this.findDropLocations(`${item.name} ${component.name}`, drops.rates, true);
         component.drops = data.length ? data : [];

--- a/build/parser.js
+++ b/build/parser.js
@@ -182,6 +182,7 @@ class Parser {
     this.addDropRate(result, data.drops);
     this.addPatchlogs(result, data.patchlogs);
     this.addAdditionalWikiaData(result, category, data.wikia);
+    this.detectPrime(result)
     this.addVaultData(result, data.vaultData);
     this.addResistanceData(result, category);
     this.applyOverrides(result);
@@ -694,7 +695,7 @@ class Parser {
           (component.uniqueName.includes('/Weapons/') &&
             !component.uniqueName.includes('/WeaponParts/') &&
             component.name !== 'Blueprint') ||
-          /Collar\w+Component/.test(component.uniqueName)
+            /Collar\w+Component/.test(component.uniqueName)
             ? this.findDropLocations(component.name, drops.rates, true)
             : this.findDropLocations(`${item.name} ${component.name}`, drops.rates, true);
         component.drops = data.length ? data : [];
@@ -757,6 +758,12 @@ class Parser {
 
     const logs = patchlogs.patchlogs.getItemChanges(target);
     if (logs.length) item.patchlogs = logs;
+  }
+
+  detectPrime(item) {
+    if (!['Primary', 'Secondary', 'Warframes', 'Sentinels', 'Mods', 'Archwing', 'Arch-Melee', 'Arch-Gun'].includes(item.category)) return;
+
+    item.isPrime = item.uniqueName.includes('Prime');
   }
 
   /**

--- a/build/parser.js
+++ b/build/parser.js
@@ -182,7 +182,7 @@ class Parser {
     this.addDropRate(result, data.drops);
     this.addPatchlogs(result, data.patchlogs);
     this.addAdditionalWikiaData(result, category, data.wikia);
-    this.detectPrime(result)
+    this.detectPrime(result);
     this.addVaultData(result, data.vaultData);
     this.addResistanceData(result, category);
     this.applyOverrides(result);
@@ -761,7 +761,12 @@ class Parser {
   }
 
   detectPrime(item) {
-    if (!['Primary', 'Secondary', 'Warframes', 'Sentinels', 'Mods', 'Archwing', 'Arch-Melee', 'Arch-Gun'].includes(item.category)) return;
+    if (
+      !['Primary', 'Secondary', 'Warframes', 'Sentinels', 'Mods', 'Archwing', 'Arch-Melee', 'Arch-Gun'].includes(
+        item.category
+      )
+    )
+      return;
 
     item.isPrime = item.uniqueName.includes('Prime');
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -149,6 +149,7 @@ declare module 'warframe-items' {
         introduced?: Update;
         attacks?: Attack[];
         i18n?: I18nBundle<UniqueName>;
+        isPrime?: boolean;
     }
 
     interface Component {


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Added an `isPrime` flag to make it easier to see which items are primed items.

---

### Evidence/screenshot/link to line

You can see my addition [on this line](#line-number-763)

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
