### PR TITLE
fix: update capitalization for requiem relics

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -342,10 +342,15 @@ class Parser {
     }
 
     // Capitalize properties which are usually all uppercase
-    const props = ['name', 'type', 'trigger', 'noise', 'rarity', 'faction'];
+    const props = ['type', 'trigger', 'noise', 'rarity', 'faction'];
     // eslint-disable-next-line no-restricted-syntax
     for (const prop of props) {
       if (item[prop]) item[prop] = title(item[prop]);
+    }
+
+    // Capitalize name for everything but requiem relics
+    if (item.name && !item.name.toLowerCase().includes('requiem') && !item.name.toLowerCase().includes('relic')) {
+      item.name = title(item.name);
     }
 
     // Remove <Archwing> from archwing names, add archwing key instead


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
This PR fixes the capitalization of requiem relics.

Before: `Requiem Ii Exceptional`
After: `Requiem II Exceptional`

From my testing this PR shouldn't break anything else, but it might be a breaking change for some people.


---

### Reproduction steps
1. Moved capitalization for names into a seperate if-statement
2. If-statement checks if the name includes both "requiem" and "relic" and if it doesn't it applies title case 

---

### Evidence/screenshot/link to line

All changes are in build/parser.js (Line 345 and 351-355)

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
