### PR TITLE
fix(i18n): inconsistency fetching i18n

### DIFF
--- a/build/scraper.js
+++ b/build/scraper.js
@@ -92,16 +92,17 @@ class Scraper {
       en: result,
     };
 
-    await Promise.all(
-      locales.map(async (locale) => {
-        i18n[locale] = [];
-        return Promise.all(
-          i18nEndpoints[locale].map(async (endpoint) => {
-            i18n[locale].push(await fetchEndpoint(endpoint, locale));
-          })
-        );
-      })
-    );
+    // Request i18n sequentially by locale to avoid getting randomly stuck in some computers
+    // It is roughly the same speed as the "all async" method but is always successfull
+    for (let i = 0; i < locales.length; i += 1) {
+      const locale = locales[i];
+      i18n[locale] = [];
+      await Promise.all(
+        i18nEndpoints[locale].map(async (endpoint) => {
+          i18n[locale].push(await fetchEndpoint(endpoint, locale));
+        })
+      );
+    }
     return i18n;
   }
 

--- a/build/scraper.js
+++ b/build/scraper.js
@@ -67,7 +67,7 @@ class Scraper {
     const i18nEndpoints = {};
     await Promise.all(
       locales.map(async (locale) => {
-        i18nEndpoints[locale] = await this.fetchEndpoints(false);
+        i18nEndpoints[locale] = await this.fetchEndpoints(false, locale);
       })
     );
     const totalEndpoints =
@@ -99,7 +99,7 @@ class Scraper {
       i18n[locale] = [];
       await Promise.all(
         i18nEndpoints[locale].map(async (endpoint) => {
-          i18n[locale].push(await fetchEndpoint(endpoint, locale));
+          i18n[locale].push(await fetchEndpoint(endpoint));
         })
       );
     }


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
1. Fixed an issue where the "Fetching API endpoints..." step would get stuck in some computers. It now has reduced concurrency but runs at roughly the same speed.
2. Fixed an issue where all language entries in the i18n were in English.

---

### Reproduction steps

For issue 1, it randomly happens, especially on Windows
For issue 2, the i18n.json file after #374 has all translations in English

---

### Evidence/screenshot/link to line

In build/scraper.js

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]** (Data files not included)
- Have I run the linter through `npm run lint`? **[Yes]**
- Is this a bug fix, feature request, or enhancement? **[Bug Fix]**
