### PR TITLE
feat: parse mod sets, avionics, focus upgrades

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,12 @@ name: Build
 on:
   schedule:
     - cron: "55 */6 * * *"
+  push:
+    branches:
+      - master
+    paths:
+      - 'build/*.js'
+      - 'config/*.json'
 
 jobs:
   build:

--- a/build/scraper.js
+++ b/build/scraper.js
@@ -79,6 +79,14 @@ class Scraper {
       const raw = await getJSON(`https://content.warframe.com/PublicExport/Manifest/${endpoint}`);
       const data = raw ? raw[`Export${category}`] : undefined;
       bar.tick();
+
+      if (category === 'Upgrades') {
+        const modSets = raw.ExportModSet.map((ms) => ({
+          ...ms,
+          type: 'Mod Set',
+        }));
+        data.push(...modSets, ...raw.ExportAvionics, ...raw.ExportFocusUpgrades);
+      }
       return { category, data };
     };
 

--- a/build/scraper.js
+++ b/build/scraper.js
@@ -81,8 +81,8 @@ class Scraper {
       bar.tick();
 
       if (category === 'Upgrades') {
-        const modSets = raw.ExportModSet.map((ms) => ({
-          ...ms,
+        const modSets = raw.ExportModSet.map((modSet) => ({
+          ...modSet,
           type: 'Mod Set',
         }));
         data.push(...modSets, ...raw.ExportAvionics, ...raw.ExportFocusUpgrades);

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -143,6 +143,13 @@
   "id": "/SyndicateDogTags",
   "name": "Medallion"
 }, {
+  "id": "Upgrades/Focus/.*Lens",
+  "regex": true,
+  "name": "Focus Lens"
+}, {
+  "id": "Upgrades/Focus",
+  "name": "Focus Way"
+},{
   "id": "/Focus/",
   "name": "Focus Lens"
 }, {
@@ -691,6 +698,12 @@
 }, {
   "id": "Grineer/Melee",
   "name": "Melee"
+}, {
+  "id": "Railjack/Abilities",
+  "name": "Plexus Mod"
+}, {
+  "id": "Mods/Railjack",
+  "name": "Plexus Mod"
 }, {
   "id": "Weapon",
   "regex": true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,9 @@ declare module 'warframe-items' {
         Resource |
         Arcane |
         Misc |
-        MinimalItem;
+        MinimalItem |
+        ModSet |
+        FocusWay;
 
     type UniqueName = string;
     type DateString = string;
@@ -196,7 +198,18 @@ declare module 'warframe-items' {
         polarity?: Polarity;
     }
     interface SingleLevelMod extends Omit<Mod, 'levelStats'> {}
-    type ModType = 
+    interface FocusWay extends Omit<Mod, 'type'> {
+        type: 'Focus Way'
+    }
+    interface ModSet extends MinimalItem, Droppable {
+        category: 'Mods';
+        stats: string[];
+        numUpgradesInSet: number;
+        buffSet?: true;
+        type: 'Mod Set Mod';
+        isPrime: false;
+    }
+    type ModType =
         'Railjack' |
         'Necramech' |
         'Warframe' |
@@ -214,7 +227,8 @@ declare module 'warframe-items' {
         'Stance' |
         'Parazon' |
         'Transmutation' |
-        'Peculiar';
+        'Peculiar' |
+        'Plexus';
     interface Mod extends MinimalItem, WikiaItem, Droppable {
         baseDrain: number;
         category: 'Mods';
@@ -776,6 +790,7 @@ declare module 'warframe-items' {
         'Misc' |
         'Mission Rewards' |
         'Mod Locations' |
+        'Mod Set Mod' |
         'Nikana' |
         'Node' |
         'Note Packs' |


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closes #178

---

### Reproduction steps
1. Check for the category, push more data from the scraped json
2. Run builds (which should trigger releases) on changes from build files

---

### Evidence/screenshot/link to line

the only weird thing is mods sets are typed as "Mod Set Mods", not that i like it... but i couldn't find a better way yet

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
