### PR TITLE
fix(tradable): proof fragment tradable property

### DIFF
--- a/config/overrides.json
+++ b/config/overrides.json
@@ -117,6 +117,9 @@
   "/Lotus/Upgrades/Mods/Warframe/AvatarMissionSpecificResistanceIce": {
     "isExilus": true
   },
+  "/Lotus/Types/Items/MiscItems/Beacon": {
+    "tradable": true
+  },
   "/Lotus/Powersuits/Archwing/DemolitionJetPack/ExhaustTrailAugmentCard": {
     "tradable": true,
     "type": "Archwing Mod"


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Set the `Proof Fragment` item tradable property to true, as i t should be

---

### Reproduction steps
1. Add an override in `overrides.json` to set the tradable property to true

---

### Evidence/screenshot/link to line

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter through `npm run lint`? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
