### PR TITLE
fix: prime melee weapons not being detected as prime

### DIFF
--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 
-import Progress from './progress.mjs';
 import dedupe from './dedupe.mjs';
-import tradable from './tradable.mjs';
+import Progress from './progress.mjs';
 import readJson from './readJson.mjs';
+import tradable from './tradable.mjs';
 
 const previousBuild = await readJson(new URL('../data/json/All.json', import.meta.url));
 const watson = await readJson(new URL('../config/dt_map.json', import.meta.url));
@@ -802,9 +802,17 @@ class Parser {
    */
   detectPrime(item) {
     if (
-      !['Primary', 'Secondary', 'Warframes', 'Sentinels', 'Mods', 'Archwing', 'Arch-Melee', 'Arch-Gun'].includes(
-        item.category
-      )
+      ![
+        'Primary',
+        'Secondary',
+        'Melee',
+        'Warframes',
+        'Sentinels',
+        'Mods',
+        'Archwing',
+        'Arch-Melee',
+        'Arch-Gun',
+      ].includes(item.category)
     )
       return;
 


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
Melee weapon category weren't present under `detectPrime` filter

---

### Reproduction steps
1. Run build
2. `Ankros Prime` should have `isPrime` but doesn't

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include the updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter through `npm run lint`? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
