### PR TITLE
fix: set `marketCost` to undefined when string is empty

### DIFF
--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -869,7 +869,7 @@ class Parser {
   addWeaponWikiaData(item, wikiaItem) {
     item.attacks = wikiaItem.attacks;
     item.ammo = wikiaItem.ammo;
-    item.marketCost = wikiaItem.marketCost || undefined;
+    item.marketCost = typeof wikiaItem.marketCost === 'number' ? wikiaItem.marketCost : undefined;
     item.bpCost = wikiaItem.bpCost;
     item.masteryReq = item.masteryReq || wikiaItem.mr;
     item.polarities = wikiaItem.polarities;

--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 
 import dedupe from './dedupe.mjs';
+import hashManager from './hashManager.mjs';
 import Progress from './progress.mjs';
 import readJson from './readJson.mjs';
 import tradable from './tradable.mjs';
-import hashManager from './hashManager.mjs';
 
 const previousBuild = await readJson(new URL('../data/json/All.json', import.meta.url));
 const watson = await readJson(new URL('../config/dt_map.json', import.meta.url));
@@ -869,7 +869,7 @@ class Parser {
   addWeaponWikiaData(item, wikiaItem) {
     item.attacks = wikiaItem.attacks;
     item.ammo = wikiaItem.ammo;
-    item.marketCost = wikiaItem.marketCost;
+    item.marketCost = wikiaItem.marketCost || undefined;
     item.bpCost = wikiaItem.bpCost;
     item.masteryReq = item.masteryReq || wikiaItem.mr;
     item.polarities = wikiaItem.polarities;

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ declare module 'warframe-items' {
         skipBuildTimePrice?: number;
         consumeOnBuild?: boolean;
         components?: Component[];
-        marketCost?: number | '';
+        marketCost?: number;
         bpCost?: number | '';
         itemCount?: number;
     }
@@ -343,7 +343,7 @@ declare module 'warframe-items' {
         damage?: DamageTypes;
         damageTypes?: DamageTypes;
         flight?: number;
-        marketCost?: number | '';
+        marketCost?: number;
         bpCost?: number | '';
         polarities?: Polarity[];
         stancePolarity?: Polarity;

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -143,65 +143,59 @@ for (const base of ['index.js', 'index.mjs']) {
         assert.strictEqual(matches.length, 1, 'There can be only One');
       });
     });
-  });
-  describe(`${base} integrity`, async function () {
-    this.timeout(10000);
-    after(() => {
-      delete require.cache[base];
-    });
-    it('weapons should only have 1 result for Mausolon', () => {
-      const matches = data.weapons
-        .filter((i) => i.name === 'Mausolon')
-        .map((i) => {
-          delete i.patchlogs;
-          return i;
-        });
-      const dd = dedupe(matches);
-      assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
-      assert.strictEqual(matches.length, 1, 'There can be only One');
-    });
-    it('warframes should only have 1 result for Octavia Prime', () => {
-      const matches = data.warframes
-        .filter((i) => i.name === 'Octavia Prime')
-        .map((i) => {
-          delete i.patchlogs;
-          return i;
-        });
-      const dd = dedupe(matches);
-      assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
-      assert.strictEqual(matches.length, 1, 'There can be only One');
-    });
-    it('items should only have 1 result for Octavia Prime', () => {
-      const matches = data.items
-        .filter((i) => i.name === 'Octavia Prime')
-        .map((i) => {
-          delete i.patchlogs;
-          return i;
-        });
-      const dd = dedupe(matches);
-      assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
-      assert.strictEqual(matches.length, 1, 'There can be only One');
-      assert(Object.keys(matches[0]).includes('components'));
-    });
-    describe('melee check', async () => {
-      data.items
-        .filter(i => ['Amphis', 'Cadus', 'Cassowar', 'Caustacyst', 'Sigma & Octantis'].includes(i.name))
-        .forEach(item => {
-          it(`${item.name} should be melee`, () => {
-            assert.equal(item.type, 'Melee');
+    describe('integrity', async () => {
+      it('weapons should only have 1 result for Mausolon', () => {
+        const matches = data.weapons
+          .filter((i) => i.name === 'Mausolon')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
           });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert.strictEqual(matches.length, 1, 'There can be only One');
+      });
+      it('warframes should only have 1 result for Octavia Prime', () => {
+        const matches = data.warframes
+          .filter((i) => i.name === 'Octavia Prime')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert.strictEqual(matches.length, 1, 'There can be only One');
+      });
+      it('items should only have 1 result for Octavia Prime', () => {
+        const matches = data.items
+          .filter((i) => i.name === 'Octavia Prime')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert.strictEqual(matches.length, 1, 'There can be only One');
+        assert(Object.keys(matches[0]).includes('components'));
+      });
+      it('should reflect melee types', () => {
+        data.items
+          .filter(i => ['Amphis', 'Cadus', 'Cassowar', 'Caustacyst', 'Sigma & Octantis'].includes(i.name))
+          .forEach((item) => {
+            assert.equal(item.type, 'Melee', `${item.name} should be melee!`);
+          });
+      });
+      it('should reflect warframe components', () => {
+        data.warframes.filter(w => !namedExclusions.includes(w.name))
+          .forEach((warframe) => {
+            assert(warframe?.components?.length > 0, `${warframe.name} should have components`);
+          });
+      });
+      it('marketCost should be a number ', () => {
+        data.items.forEach((item) => {
+          assert(['number', 'undefined'].includes(typeof item.marketCost), `${item.name} marketCost should be a number if present`);
         });
-    });
-    data.warframes.filter(w => !namedExclusions.includes(w.name)).forEach((warframe) => {
-      it(`${warframe.name} should have components`, () => {
-        assert(warframe?.components?.length > 0);
       });
     });
-
-    it('marketCost should be a number when present', () => {
-      data.items.filter(i => !namedExclusions.includes(i.marketCost)).forEach((item) => {
-        assert(item.marketCost)
-      })
-    }) 
   });
 }

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { resolve } from 'node:path';
 import dedupe from '../build/dedupe.mjs';
 
-import { createRequire } from 'module'
+import { createRequire } from 'module';
 const require = createRequire(import.meta.url)
 
 let itemPath;
@@ -197,5 +197,11 @@ for (const base of ['index.js', 'index.mjs']) {
         assert(warframe?.components?.length > 0);
       });
     });
+
+    it('marketCost should be a number when present', () => {
+      data.items.filter(i => !namedExclusions.includes(i.marketCost)).forEach((item) => {
+        assert(item.marketCost)
+      })
+    }) 
   });
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Looks like the wikia doesn't have an in-game market price for all items so instead of an empty string it should be set to undefined.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

1.  Run build
2. Check Twin Krohkur
3. `marketCost: ""`

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->
![image](https://user-images.githubusercontent.com/6075693/213961541-c7b19464-507c-4099-89d7-5cafd8b09212.png)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
