### PR TITLE
Fix: Correctly categorize sigils

### DIFF
--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -17,6 +17,9 @@
   "id": "/Archwing/Melee",
   "name": "Arch-Melee"
 }, {
+  "id": "/Sigils",
+  "name": "Sigil"
+}, {
   "id": "/Skins",
   "name": "Skin"
 }, {
@@ -73,9 +76,6 @@
 }, {
   "id": "/Keys",
   "name": "Key"
-}, {
-  "id": "/Sigils",
-  "name": "Sigil"
 }, {
   "id": "/Game/QuartersWallpapers",
   "name": "Ship Decoration"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Sigils where being marked as skins instead of being put in their own category.
Tracked down the issue being the order of the entry within the `itemTypes.json` file.

Since sigils have unique names like `/Lotus/Upgrades/Skins/Sigils/xxx` it matched `/Skins` first. Now the type is correctly set.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->
1. Run build
2. See that sigils formerly being put in `Skins.json` are now in `Sigils.json` and `Sigils.json` is updated again.
3. For example `Nightwave Sigil` is no longer in `Skins.json`
---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->
Before:
![image](https://user-images.githubusercontent.com/2438964/231159482-cb16bc89-782b-47ce-99a0-1f0556e4e2ce.png)

After:
![image](https://user-images.githubusercontent.com/2438964/231159346-3f63853d-9d17-4478-abf6-42171434b833.png)


### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
