### PR TITLE
docs(readme): Remove mentions of NexusHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ that you could possibly need. To give you some idea:
 And tons more item specific data. Check out [/data/json](/data/json) to get an
 idea.
 
-You can also rest assured that this repository will be maintained for as long
-as Warframe stays alive, as it is has been built to provide all item data for [NexusHub](https://github.com/nexus-devs/NexusHub).
-
 <br>
 
 ### Installation


### PR DESCRIPTION
This is a small readme change to remove the unfitting description about Nexus. The service has been inactive for a while, so the description no longer makes any sense.