### PR TITLE
fix(types): explicit export path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     "types": "./index.d.ts",
     "import": "./index.mjs",
-    "require": "./index.js"
+    "default": "./index.js"
   },
   "scripts": {
     "build": "node ./build/build.mjs",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     "types": "./index.d.ts",
     "import": "./index.mjs",
-    "default": "./index.js"
+    "require": "./index.js"
   },
   "scripts": {
     "build": "node ./build/build.mjs",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./index.mjs",
     "require": "./index.js"
   },


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
![image](https://github.com/WFCD/warframe-items/assets/18660606/7fb458b0-85c1-42cc-9eda-755c20416e19)
Fixed types not being exported properly through package.json for ESM projects

---

### Reproduction steps
Install warframe-items as a dependency on an ESM Typescript project (Webstorm)

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
