### PR TITLE
fix: add new Sex type for Xaku

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -682,10 +682,7 @@ declare module 'warframe-items' {
         'Sabotage' |
         'Survival'
 
-    type Sex =
-        'Male' |
-        'Female' |
-        'Androgynous'
+    type Sex = 'Male' | 'Female' | 'Androgynous' | 'Non-binary (Pluriform)';
 
     type ShotType =
         'Continuous' |


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Type validation was failing on Xaku (warframe) due to missing (new) Sex typing

---

### Reproduction steps
`npm run typings` returns code 1 (fail)

---

### Evidence/screenshot/link to line

```typescript
type Sex = 'Male' | 'Female' | 'Androgynous' | 'Non-binary (Pluriform)';
```

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is it a bug fix, feature request, or enhancement? **[Bug Fix]**
