### PR TITLE
fix(types): SentinelWeapons typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,7 +155,7 @@ declare module 'warframe-items' {
     }
     interface SentinelWeapon extends Omit<Melee, 'category'> {
         sentinel: true;
-        productCategory: 'Melee';
+        productCategory: 'SentinelWeapons';
         category: 'SentinelWeapons';
     }
     interface ExaltedWeapon extends Omit<Gun, 'category'>, Omit<Melee, 'category'>, Omit<Weapon, 'category'> {
@@ -608,6 +608,7 @@ declare module 'warframe-items' {
         'OperatorAmps' |
         'Pistols' |
         'Sentinels' |
+        'SentinelWeapons' |
         'SpaceGuns' |
         'SpaceMelee' |
         'SpaceSuits' |

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module 'warframe-items' {
         i18n: BundleofI18nBundle<Locale>;
     }
     interface ItemsOptions {
-        category: Array<Category | 'SentinelWeapons'>;
+        category: Array<Category>;
         ignoreEnemies?: boolean;
         i18n?: boolean|string[];
         i18nOnObject?: boolean;
@@ -155,15 +155,15 @@ declare module 'warframe-items' {
     }
     interface SentinelWeapon extends Omit<Melee, 'category'> {
         sentinel: true;
-        productCategory: 'SentinelWeapons';
-        category: 'Primary';
+        productCategory: 'Melee';
+        category: 'SentinelWeapons';
     }
     interface ExaltedWeapon extends Omit<Gun, 'category'>, Omit<Melee, 'category'>, Omit<Weapon, 'category'> {
         category: 'Misc';
         type: 'Exalted Weapon';
     }
     interface Weapon extends Equippable, Buildable, Attackable, WikiaItem, BaseItem {
-        category: Gun['category'] | Melee['category'];
+        category: Gun['category'] | Melee['category'] | SentinelWeapon['category'];
         fusionLimit?: number;
         secondsPerShot?: number;
         damagePerSecond?: number;
@@ -607,7 +607,6 @@ declare module 'warframe-items' {
         'Melee' |
         'OperatorAmps' |
         'Pistols' |
-        'SentinelWeapons' |
         'Sentinels' |
         'SpaceGuns' |
         'SpaceMelee' |


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
SentinelWeapons was incorrectly typed as it was not typed as a Category and should be as it behaves similarly to "Primary" and "Secondary" categories.

---

### Reproduction steps
```
import Items, { Category } from "warframe-items";

// Originally, this instantiation will not work because "SentinelWeapons" is not typed as a Category but should be.
const weaponTypes: Category[] = ["Primary", "Secondary", "Melee", "Arch-Gun", "Arch-Melee", "SentinelWeapons"];
const items = new Items({ category:  });
```

---

### Evidence/screenshot/link to line
![image](https://github.com/WFCD/warframe-items/assets/6471682/067c638b-257b-4648-9d74-0d86d91287f5)

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
