### PR TITLE
feat: scrape archwings and companions from wikia

### DIFF
--- a/build/scraper.mjs
+++ b/build/scraper.mjs
@@ -5,6 +5,8 @@ import { Generator as RelicGenerator } from '@wfcd/relics';
 import patchlogs from 'warframe-patchlogs';
 
 import Progress from './progress.mjs';
+import ArchwingScraper from './wikia/scrapers/ArchwingScraper.mjs';
+import CompanionScraper from './wikia/scrapers/CompanionScraper.mjs';
 import ModScraper from './wikia/scrapers/ModScraper.mjs';
 import WeaponScraper from './wikia/scrapers/WeaponScraper.mjs';
 import WarframeScraper from './wikia/scrapers/WarframeScraper.mjs';
@@ -195,7 +197,7 @@ class Scraper {
    * @returns {WikiaData}
    */
   async fetchWikiaData() {
-    const bar = new Progress('Fetching Wikia Data', 5);
+    const bar = new Progress('Fetching Wikia Data', 7);
     const ducats = [];
     const ducatsWikia = await get('http://warframe.wikia.com/wiki/Ducats/Prices/All', true);
     const $ = load(ducatsWikia);
@@ -215,6 +217,10 @@ class Scraper {
     bar.tick();
     const versions = await new VersionScraper().scrape();
     bar.tick();
+    const archwings = await new ArchwingScraper().scrape();
+    bar.tick();
+    const companions = await new CompanionScraper().scrape();
+    bar.tick();
 
     return {
       weapons,
@@ -222,6 +228,8 @@ class Scraper {
       mods,
       versions,
       ducats,
+      archwings,
+      companions,
     };
   }
 

--- a/build/wikia/scrapers/ArchwingScraper.mjs
+++ b/build/wikia/scrapers/ArchwingScraper.mjs
@@ -1,0 +1,8 @@
+import WikiaDataScraper from '../WikiaDataScraper.mjs';
+import transformWarframe from '../transformers/transformWarframe.mjs';
+
+export default class ArchwingScraper extends WikiaDataScraper {
+  constructor() {
+    super('https://warframe.fandom.com/wiki/Module:Warframes/data?action=edit', 'Archwing', transformWarframe);
+  }
+}

--- a/build/wikia/scrapers/CompanionScraper.mjs
+++ b/build/wikia/scrapers/CompanionScraper.mjs
@@ -1,0 +1,8 @@
+import WikiaDataScraper from '../WikiaDataScraper.mjs';
+import transformCompanion from '../transformers/transformCompanion.mjs';
+
+export default class CompanionScraper extends WikiaDataScraper {
+  constructor() {
+    super('https://warframe.fandom.com/wiki/Module:Companions/data?action=edit', 'Companion', transformCompanion);
+  }
+}

--- a/build/wikia/transformers/transformCompanion.mjs
+++ b/build/wikia/transformers/transformCompanion.mjs
@@ -1,0 +1,36 @@
+/**
+ * Transform wikia lua companions into usable standardized json
+ * @param {Object} oldCompanion old companion in lua format
+ * @param {Record<string, unknown>} imageUrls name-url pairs
+ * @returns {Promise<WikiaCompanion>}
+ */
+export default async (oldCompanion, imageUrls) => {
+  let newCompanion;
+  if (!oldCompanion || !oldCompanion.Name) {
+    return undefined;
+  }
+
+  try {
+    const { Image, Mastery, Polarities, Stamina, Introduced, Vaulted, VaultDate, EstimatedVaultDate } = oldCompanion;
+    const { Name } = oldCompanion;
+
+    newCompanion = {
+      name: Name,
+      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(
+        Name.replace(/\s/g, '_').replace('_Prime', '/Prime')
+      )}`,
+      mr: Mastery || 0,
+      polarities: Polarities,
+      stamina: Stamina,
+      introduced: Introduced,
+      vaulted: Vaulted || undefined,
+      vaultDate: VaultDate,
+      estimatedVaultDate: EstimatedVaultDate,
+      thumbnail: imageUrls?.[Image],
+    };
+  } catch (error) {
+    console.error(`Error parsing ${oldCompanion.Name}`);
+    console.error(error);
+  }
+  return newCompanion;
+};

--- a/build/wikia/transformers/transformerArchwing.mjs
+++ b/build/wikia/transformers/transformerArchwing.mjs
@@ -1,0 +1,37 @@
+import transformPolarity from './transformPolarity.mjs';
+
+/**
+ * Transform wikia lua archwings into usable standardized json
+ * @param {Object} oldWings old archwing in lua format
+ * @param {Record<string, unknown>} imageUrls name-url pairs
+ * @returns {Promise<WikiaArchwing>}
+ */
+export default async (oldWings, imageUrls) => {
+  let newWings;
+  if (!oldWings || !oldWings.Name) {
+    return undefined;
+  }
+
+  try {
+    const { Image, Mastery, Polarities, Sprint, Introduced, Vaulted } = oldWings;
+    const { Name } = oldWings;
+
+    newWings = {
+      name: Name,
+      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(
+        Name.replace(/\s/g, '_').replace('_Prime', '/Prime')
+      )}`,
+      mr: Mastery || 0,
+      polarities: Polarities,
+      sprint: Sprint,
+      introduced: Introduced,
+      vaulted: Vaulted || undefined,
+      thumbnail: imageUrls?.[Image],
+    };
+    newWings = transformPolarity(oldWings, newWings);
+  } catch (error) {
+    console.error(`Error parsing ${oldWings.Name}`);
+    console.error(error);
+  }
+  return newWings;
+};


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Doesn't fix anything just lets scarper pull information about archwings and companions. Not sure how to do everything in js so I only used the bare minimum for companions. As Archwings share a lot of information from warframes I used the same transformer.

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**
