### PR TITLE
fix: archwing quest getting marked as an Archwing

### DIFF
--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -30,7 +30,7 @@
   "regex": true,
   "name": "Archwing Mod"
 }, {
-  "id": "/Archwing",
+  "id": "/Archwing/",
   "name": "Archwing"
 }, {
   "id": "/HeavyWeapons",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixed a case where the Archwing item type was being assigned to the Archwing quest

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

![image](https://github.com/WFCD/warframe-items/assets/6075693/fe70ead0-0d54-4ba4-82d6-5cac3590a4ae)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
