### PR TITLE
fix: check for IncarnonAdapter before Melee or Rifles

### DIFF
--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -702,6 +702,9 @@
   "id": "ClanTech/.*Weapon",
   "regex": true,
   "name": "Rifle"
+},  {
+  "id": "IncarnonAdapters",
+  "name": "Equipment Adapter"
 }, {
   "id": "Secondary",
   "name": "Pistol"
@@ -749,9 +752,6 @@
   "name": "Resource"
 }, {
   "id": "WeaponAdapter",
-  "name": "Equipment Adapter"
-}, {
-  "id": "IncarnonAdapters",
   "name": "Equipment Adapter"
 }, {
   "id": "Unlocker",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixes Ack & brunt having being marked as a melee instead of an Incarnon adapter

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

![image](https://github.com/WFCD/warframe-items/assets/6075693/530d6614-2901-4a0c-bcba-1ef309266823)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
