### PR TITLE
fix: add Skins ItemType regex for melee items that are just skins

### DIFF
--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -739,7 +739,7 @@
   "append": true,
   "name": " Mod"
 }, {
-  "id": "/Melee/",
+  "id": "/Melee",
   "name": "Melee"
 }, {
   "id": "SwordsWeapon$",

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -23,6 +23,10 @@
   "id": "/Skins",
   "name": "Skin"
 }, {
+  "id": "Skin$",
+  "regex": true,
+  "name": "Skins"
+}, {
   "id": "/Mods/Archwing",
   "name": "Archwing Mod"
 }, {
@@ -735,7 +739,7 @@
   "append": true,
   "name": " Mod"
 }, {
-  "id": "/Melee",
+  "id": "/Melee/",
   "name": "Melee"
 }, {
   "id": "SwordsWeapon$",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixes Dual Swords Stavika Skin being given the the type melee

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line
![Screenshot 2024-02-24 162617](https://github.com/WFCD/warframe-items/assets/6075693/c1196937-aed7-4d51-acd5-17d811f90e31)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
