### PR TITLE
fix: add universal Aura polarity

### DIFF
--- a/config/polarities.json
+++ b/config/polarities.json
@@ -1,25 +1,38 @@
-[{
-  "id": "AP_DEFENSE",
-  "name": "Vazarin"
-}, {
-  "id": "AP_TACTIC",
-  "name": "Naramon"
-}, {
-  "id": "AP_ATTACK",
-  "name": "Madurai"
-}, {
-  "id": "AP_POWER",
-  "name": "Zenurik"
-}, {
-  "id": "AP_PRECEPT",
-  "name": "Penjaga"
-}, {
-  "id": "AP_WARD",
-  "name": "Unairu"
-}, {
-  "id": "AP_UMBRA",
-  "name": "Umbra"
-}, {
-  "id": "AP_UNIVERSAL",
-  "name": "Universal"
-}]
+[
+  {
+    "id": "AP_DEFENSE",
+    "name": "Vazarin"
+  },
+  {
+    "id": "AP_TACTIC",
+    "name": "Naramon"
+  },
+  {
+    "id": "AP_ATTACK",
+    "name": "Madurai"
+  },
+  {
+    "id": "AP_POWER",
+    "name": "Zenurik"
+  },
+  {
+    "id": "AP_PRECEPT",
+    "name": "Penjaga"
+  },
+  {
+    "id": "AP_WARD",
+    "name": "Unairu"
+  },
+  {
+    "id": "AP_UMBRA",
+    "name": "Umbra"
+  },
+  {
+    "id": "AP_UNIVERSAL",
+    "name": "Universal"
+  },
+  {
+    "id": "AP_ANY",
+    "name": "Aura"
+  }
+]

--- a/test/utilities/find.spec.mjs
+++ b/test/utilities/find.spec.mjs
@@ -56,7 +56,7 @@ describe('#loadMods', () => {
 
     const expectedRiven = {
       uniqueName: '/Lotus/Upgrades/Mods/Randomized/LotusRifleRandomModRare',
-      polarity: 'Varazin',
+      polarity: 'Vazarin',
       rarity: 'Common',
       imageName: 'rifle-riven-mod.png',
       category: 'Mods',


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Looks like DE made Dreamer's Bond a universal aura which shows up as AP_ANY when parsed in warframe-items.

https://forums.warframe.com/topic/1391568-pc-dante-unbound-deep-archimedea-hotfix-3553/?ct=1712923112

> Changed the Polarity of the Dreamer’s Bond Aura Mod from Madurai to Universal, as promised in the Whispers in the Walls: 35.1 Update where it was introduced!  

Quick note `lint-staged` seems to be running on all json files during pre-commit

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line
https://github.com/WFCD/warframe-items/blob/e9eaa0e1500903267a356cf604c01fc4ea7cf434/data/warnings.json#L24

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
