### PR TITLE
fix: corufell incorrect weapon type

### DIFF
--- a/config/overrides.json
+++ b/config/overrides.json
@@ -339,5 +339,9 @@
   },
   "/Lotus/Weapons/Tenno/Pistols/AllNew1hSG/AllNew1hSG": {
     "isPrime": true
+  },
+  "/Lotus/Weapons/Tenno/Archwing/Melee/ExaltedArchScythe/ExaltedAWScytheWeapon": {
+    "category": "Melee",
+    "type": "Melee"
   }
 }


### PR DESCRIPTION
### What did you fix?
Corufell has a `uniqueName` of `/Lotus/Weapons/Tenno/Archwing/Melee/ExaltedArchScythe/ExaltedAWScytheWeapon` and as such, is parsed as an `Arch-Melee` when it is actually a `Melee`.

This PR adds an override specifically for this weapon to have the correct `category` and `type`.

---

### Reproduction steps

---

### Evidence/screenshot/link to line

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
