### PR TITLE
fix: implement Items.map so 'length' stays the same

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,9 +161,21 @@ module.exports = class Items extends Array {
    */
   filter(fn) {
     const A = [];
-
     for (const el of this) {
       if (fn(el)) A.push(el);
+    }
+    return A;
+  }
+
+  /**
+   * @Override Array.prototype.map
+   *
+   * Needs to be reimplemented here because it exhibits the same issues as Array.prototype.filter.
+   */
+  map(fn) {
+    const A = [];
+    for (const el of this) {
+      A.push(fn(el));
     }
     return A;
   }

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -267,6 +267,16 @@ for (const base of ['index.js', 'index.mjs']) {
           );
         });
       });
+      it('should not change size when using filter', async () => {
+        const items = await wrapConstr({ category: ['Arch-Gun'] });
+        const realLength = items.length;
+        assert(realLength === items.filter(() => true).length);
+      });
+      it('should not change size when using map', async () => {
+        const items = await wrapConstr({ category: ['Arch-Gun'] });
+        const realLength = items.length;
+        assert(realLength === items.map((x) => x).length);
+      });
     });
   });
 }


### PR DESCRIPTION
Fixed the same issue as what you apparently already fixed for 'filter'.