### PR TITLE
perf: skip downloading images for generic Arcanes

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -232,7 +232,7 @@ class Build {
     const cached = imageCache.find((c) => c.uniqueName === item.uniqueName);
 
     // We'll use a custom blueprint image
-    if (item.name === 'Blueprint') return;
+    if (item.name === 'Blueprint' || item.name === 'Arcane') return;
 
     // Don't download component images or relic images twice
     if (isComponent || item.type === 'Relic') {

--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -559,6 +559,11 @@ class Parser {
       item.imageName += `-${encode(item.uniqueName)}`;
     }
 
+    // Give generic arcane entries the same treamt asaa blueprint with a static arcane image
+    if (item.name === 'Arcane') {
+      item.imageName = 'arcane';
+    }
+
     // Add original file extension
     item.imageName += `.${ext}`;
   }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
There are 15 generic Arcane entries that use the same base image with different names. This just does the same as blueprints where a single image exist for them.

The static image already exist inside `data/img`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

![image](https://github.com/user-attachments/assets/7bae29b3-67c5-4018-94d2-5f2d94239573)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
