### PR TITLE
fix: remove the extra `prime` in older secondary weapons

### DIFF
--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -548,7 +548,11 @@ class Parser {
     // components, so we'll keep the prime in the name.
     if (item.parent) {
       item.imageName = item.imageName.replace(`${encode(item.parent)}-`, '');
-      if (item.name.includes('Prime')) item.imageName = `prime-${item.imageName}`;
+      if (item.name.includes('Prime')) {
+        item.imageName = `prime-${item.imageName}`;
+        // check if the image name ends with prime as some older prime secondaries use the full parent name
+        if (/prime$/.test(item.imageName)) item.imageName = item.imageName.replace(/-prime$/, '');
+      }
     }
 
     // Relics should use the same image based on type, as they all use the same.


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Closes #636 

Looks like older prime secondary weapons (maybe primary too didn't check) used the full parent name i.e. `aklex-prime-lex-prime` so check if the string ends with prime and remove it.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line
Search for `prime-lex-prime`

https://raw.githubusercontent.com/WFCD/warframe-items/0b3f4f3c58b19ec8735676fdcdc9c9ccb1f95161/data/json/Secondary.json

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
