### PR TITLE
fix: exclude `Helminth` when testing warframe regression

### DIFF
--- a/test/index.regression.spec.mjs
+++ b/test/index.regression.spec.mjs
@@ -13,7 +13,7 @@ const data = {
   mods: undefined,
 };
 
-const namedExclusions = ['Excalibur Prime'];
+const namedExclusions = ['Excalibur Prime', 'Helminth'];
 
 data.items = await grab('items');
 data.weapons = await grab('weapons');


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Regression test failed when checking warframes for components as Helminth does not have components 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
