### PR TITLE
fix: masterable check for modular parts and Pets

### DIFF
--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -1070,11 +1070,10 @@ class Parser {
    * @param {Item} item the item to add the attribute to
    */
   applyMasterable(item) {
-    item.masterable = masterableCategories.includes(item.category);
+    item.masterable = masterableCategories.categories.includes(item.category);
 
     if (item.type?.includes('Component') || item.category === 'Pets') {
-      const regex =
-        /^((?=.*Amp)|(?=.*Modular))(?=.*Barrel).*$|^(?=.*Pet)(?=.*Head).*$|PetPowerSuit|PvPVariantTip|^(?=.*Hoverboard)(?=.*Deck).*$/;
+      const regex = new RegExp(masterableCategories.regex);
       item.masterable = regex.test(item.uniqueName);
     }
   }

--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -1072,7 +1072,7 @@ class Parser {
   applyMasterable(item) {
     item.masterable = masterableCategories.includes(item.category);
 
-    if (item.type?.includes('Component') || item.category == 'Pets') {
+    if (item.type?.includes('Component') || item.category === 'Pets') {
       const regex =
         /^((?=.*Amp)|(?=.*Modular))(?=.*Barrel).*$|^(?=.*Pet)(?=.*Head).*$|PetPowerSuit|PvPVariantTip|^(?=.*Hoverboard)(?=.*Deck).*$/;
       item.masterable = regex.test(item.uniqueName);

--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -1071,6 +1071,12 @@ class Parser {
    */
   applyMasterable(item) {
     item.masterable = masterableCategories.includes(item.category);
+
+    if (item.type?.includes('Component') || item.category == 'Pets') {
+      const regex =
+        /^((?=.*Amp)|(?=.*Modular))(?=.*Barrel).*$|^(?=.*Pet)(?=.*Head).*$|PetPowerSuit|PvPVariantTip|^(?=.*Hoverboard)(?=.*Deck).*$/;
+      item.masterable = regex.test(item.uniqueName);
+    }
   }
 
   addResistanceData(item, category) {

--- a/config/masterableCategories.json
+++ b/config/masterableCategories.json
@@ -1,10 +1,13 @@
-[
-  "Archwing",
-  "Arch-Melee",
-  "Arch-Gun",
-  "Melee",
-  "Primary",
-  "Secondary",
-  "Sentinels",
-  "Warframes"
-]
+{
+  "regex": "^((?=.*Amp)|(?=.*Modular))(?=.*Barrel).*$|^(?=.*Pet)(?=.*Head).*$|PetPowerSuit|PvPVariantTip|^(?=.*Hoverboard)(?=.*Deck).*$",
+  "categories": [
+    "Archwing",
+    "Arch-Melee",
+    "Arch-Gun",
+    "Melee",
+    "Primary",
+    "Secondary",
+    "Sentinels",
+    "Warframes"
+  ]
+}

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -216,10 +216,18 @@ for (const base of ['index.js', 'index.mjs']) {
       it('items should be marked masterable correctly ', async () => {
         const items = await wrapConstr({ ignoreEnemies: true });
         items.forEach((item) => {
-          const masterable = masterableCategories.includes(item.category);
+          const masterable = (category, type, uniqueName) => {
+            if (type?.includes('Component') || category === 'Pets') {
+              const regex = new RegExp(masterableCategories.regex);
+              return regex.test(uniqueName);
+            }
+
+            return masterableCategories.categories.includes(category);
+          };
+
           assert.equal(
             item.masterable,
-            masterable,
+            masterable(item.category, item.type, item.uniqueName),
             `${item.name} should be marked as ${!masterable ? 'not ' : ''}masterable`
           );
         });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Checks masterablity for more complicated parts

For pets there are a lot of items that belong to the `Pets` category and are also `Pet Resources` so the regex matches based on the uniquename containing `PetPowerSuit`, this way we can target certain items in the category without breaking the previous implementation if we were to add `Pets` to `masterableCategories`  

For Modular parts only certain pieces contribute to mastery
* Zaws, the grip 
* MOA & Hound, the model 
* Amps, the prism
* Kit Guns, the chamber
* K-Drives, the board

Here is a break down of the regex with the unique names I tested against https://regex101.com/r/H7LXrd/1

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced item processing to include more items as masterable based on type or category, particularly components and pets.
	- Improved data structure for masterable categories, allowing for more nuanced evaluations through regex matching.

- **Bug Fixes**
	- Adjusted handling of warnings for missing data to improve tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->