### PR TITLE
fix(ci): bump `max_old_space_size` from `4096` to `8192` MB

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
       - run: sh .github/workflows/regression.sh
       - uses: stefanzweifel/git-auto-commit-action@v5
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
+          NODE_OPTIONS: '--max_old_space_size=8192'
         with:
           skip_dirty_check: false
           commit_message: 'fix(items): new items'

--- a/.github/workflows/regression.sh
+++ b/.github/workflows/regression.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 {
-  NODE_OPTIONS=--max_old_space_size=4096 npm test && exit 0
+  NODE_OPTIONS=--max_old_space_size=8192 npm test && exit 0
 } || {
   echo "Regression failed, rolling back..."
   cd "${GITHUB_WORKSPACE}" && git checkout -- . && exit 0


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Bump the max memory size of V8's old memory section from `4096` to `8192` megabytes
---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
