### PR TITLE
feat: add `uniqueName` to component relic drops

### DIFF
--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -1048,8 +1048,9 @@ class Parser {
       // Relic names are /(Lith|Meso|Neo|Axi|Requiem) (\w+)/
       const related = relics.filter((relic) => relic.name.toLowerCase() === relicName);
 
-      if (link) [relicItem.uniqueName] = Array.from(new Set(related.map((relic) => relic.uniqueName).flat()));
-      else {
+      if (link) {
+        [relicItem.uniqueName] = Array.from(new Set(related.map((relic) => relic.uniqueName).flat()));
+      } else {
         relicItem.locations = Array.from(new Set(related.map((relic) => relic.locations).flat()));
         relicItem.rewards = Array.from(new Set(related.map((relic) => relic.rewards).flat()));
         [relicItem.marketInfo] = Array.from(new Set(related.map((relic) => relic.warframeMarket)));

--- a/index.d.ts
+++ b/index.d.ts
@@ -585,6 +585,7 @@ declare module 'warframe-items' {
     rarity?: Rarity;
     chance: number | null;
     rotation?: Rotation;
+    uniqueName?: string;
   }
   interface PatchLog {
     name: string;


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add the relic's `uniqueName` as a pseudo link in order to make it easier to pull or link the full relics's information

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced relic drop detection and processing logic
	- Added optional unique name support for drops

- **Refactor**
	- Improved relic data handling method for better clarity and maintainability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->