### PR TITLE
fix: `Loaned Weapons` being marked as a `Rifle` instead of `Misc`

### DIFF
--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -1027,6 +1027,10 @@
     "name": "Railjack Turret"
   },
   {
+    "id": "/Quest",
+    "name": "Misc"
+  },
+  {
     "id": "Weapon",
     "regex": true,
     "name": "Rifle"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
`Loaned Weapons` was being marked as a `Rifle` instead of `Misc`. This item seems to be a quest item that the player gets only for the hex quest

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new item type category for quests, classified under "Misc"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->