### PR TITLE
feat: migrate all fandom links to the official wiki

### DIFF
--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -896,14 +896,18 @@ class Parser {
    * @param {WikiaData} wikiaData from wikia to apply
    */
   addAdditionalWikiaData(item, category, wikiaData) {
-    if (!['weapons', 'warframes', 'mods', 'upgrades'].includes(category.toLowerCase())) return;
+    if (!['weapons', 'warframes', 'mods', 'upgrades', 'sentinels'].includes(category.toLowerCase())) return;
 
-    const wikiaItem = wikiaData[category === 'Upgrades' ? 'mods' : category.toLowerCase()]
-      .filter((i) => i)
-      .find((i) => i.name === item.name);
+    let wikiCategory = category.toLowerCase();
+    if (category === 'Upgrades') wikiCategory = 'mods';
+    if (item.category == 'Archwing') wikiCategory = 'archwings';
+    if (category === 'Sentinels') wikiCategory = 'companions';
+
+    const wikiaItem = wikiaData[wikiCategory].filter((i) => i).find((i) => i.name === item.name);
     if (!wikiaItem) return;
 
     switch (category.toLowerCase()) {
+      case 'sentinels':
       case 'warframes':
         this.addWarframeWikiaData(item, wikiaItem);
         break;

--- a/build/parser.mjs
+++ b/build/parser.mjs
@@ -900,7 +900,7 @@ class Parser {
 
     let wikiCategory = category.toLowerCase();
     if (category === 'Upgrades') wikiCategory = 'mods';
-    if (item.category == 'Archwing') wikiCategory = 'archwings';
+    if (item.category === 'Archwing') wikiCategory = 'archwings';
     if (category === 'Sentinels') wikiCategory = 'companions';
 
     const wikiaItem = wikiaData[wikiCategory].filter((i) => i).find((i) => i.name === item.name);

--- a/build/scraper.mjs
+++ b/build/scraper.mjs
@@ -215,7 +215,7 @@ class Scraper {
   async fetchWikiaData() {
     const bar = new Progress('Fetching Wikia Data', 7);
     const ducats = [];
-    const ducatsWikia = await get('https://warframe.fandom.com/wiki/Ducats/Prices/All', true);
+    const ducatsWikia = await get('https://wiki.warframe.com/w/Ducats/Prices/All', true);
     const $ = load(ducatsWikia);
 
     $('.mw-content-text table tbody tr').each(function () {

--- a/build/wikia/WikiaDataScraper.mjs
+++ b/build/wikia/WikiaDataScraper.mjs
@@ -9,7 +9,7 @@ import fetch from 'node-fetch';
 
 const run = promisify(cmd.get);
 
-const blueprintUrl = 'https://warframe.fandom.com/wiki/Module:Blueprints/data?action=edit';
+const blueprintUrl = 'https://wiki.warframe.com/w/Module:Blueprints/data?action=edit';
 
 const getLuaData = async (url) => {
   try {
@@ -71,7 +71,7 @@ const getImageUrls = async (things) => {
 
   const urlRequests = titleBatches.map((titleBatch) => {
     const params = ['action=query', `titles=${titleBatch.join('|')}`, 'prop=imageinfo', 'iiprop=url', 'format=json'];
-    const request = new fetch.Request(`https://warframe.fandom.com/api.php?${params.join('&')}`);
+    const request = new fetch.Request(`https://wiki.warframe.com/api.php?${params.join('&')}`);
     return fetch(request).then((d) => d.json());
   });
 

--- a/build/wikia/scrapers/ArchwingScraper.mjs
+++ b/build/wikia/scrapers/ArchwingScraper.mjs
@@ -3,6 +3,6 @@ import transformWarframe from '../transformers/transformWarframe.mjs';
 
 export default class ArchwingScraper extends WikiaDataScraper {
   constructor() {
-    super('https://warframe.fandom.com/wiki/Module:Warframes/data?action=edit', 'Archwing', transformWarframe);
+    super('https://wiki.warframe.com/w/Module:Warframes/data?action=edit', 'Archwing', transformWarframe);
   }
 }

--- a/build/wikia/scrapers/CompanionScraper.mjs
+++ b/build/wikia/scrapers/CompanionScraper.mjs
@@ -3,6 +3,6 @@ import transformCompanion from '../transformers/transformCompanion.mjs';
 
 export default class CompanionScraper extends WikiaDataScraper {
   constructor() {
-    super('https://warframe.fandom.com/wiki/Module:Companions/data?action=edit', 'Companion', transformCompanion);
+    super('https://wiki.warframe.com/w/Module:Companions/data?action=edit', 'Companion', transformCompanion);
   }
 }

--- a/build/wikia/scrapers/VersionScraper.mjs
+++ b/build/wikia/scrapers/VersionScraper.mjs
@@ -3,6 +3,6 @@ import transformVersion from '../transformers/transformVersion.mjs';
 
 export default class VersionScraper extends WikiaDataScraper {
   constructor() {
-    super('https://warframe.fandom.com/wiki/Module:Version/data?action=edit', 'Version', transformVersion);
+    super('https://wiki.warframe.com/w/Module:Version/data?action=edit', 'Version', transformVersion);
   }
 }

--- a/build/wikia/scrapers/WarframeScraper.mjs
+++ b/build/wikia/scrapers/WarframeScraper.mjs
@@ -3,6 +3,6 @@ import transformWarframe from '../transformers/transformWarframe.mjs';
 
 export default class WarframeScraper extends WikiaDataScraper {
   constructor() {
-    super('https://warframe.fandom.com/wiki/Module:Warframes/data?action=edit', 'Warframe', transformWarframe);
+    super('https://wiki.warframe.com/w/Module:Warframes/data?action=edit', 'Warframe', transformWarframe);
   }
 }

--- a/build/wikia/scrapers/WeaponScraper.mjs
+++ b/build/wikia/scrapers/WeaponScraper.mjs
@@ -1,7 +1,7 @@
 import WikiaDataScraper from '../WikiaDataScraper.mjs';
 import transformWeapon from '../transformers/transformWeapon.mjs';
 
-const base = 'https://warframe.fandom.com/wiki/Module:Weapons/data';
+const base = 'https://wiki.warframe.com/w/Module:Weapons/data';
 const suffix = '?action=edit';
 const subModules = ['archwing', 'companion', 'melee', 'misc', 'modular', 'primary', 'secondary', 'railjack'];
 

--- a/build/wikia/transformers/polarities.mjs
+++ b/build/wikia/transformers/polarities.mjs
@@ -6,4 +6,6 @@ export default {
   Ability: 'zenurik',
   R: 'unairu',
   Aura: 'aura',
+  Y: 'penjaga',
+  O: 'any',
 };

--- a/build/wikia/transformers/transformCompanion.mjs
+++ b/build/wikia/transformers/transformCompanion.mjs
@@ -1,3 +1,5 @@
+import transformPolarity from './transformPolarity.mjs';
+
 /**
  * Transform wikia lua companions into usable standardized json
  * @param {Object} oldCompanion old companion in lua format
@@ -26,6 +28,7 @@ export default async (oldCompanion, imageUrls) => {
       estimatedVaultDate: EstimatedVaultDate,
       thumbnail: imageUrls?.[Image],
     };
+    newCompanion = transformPolarity(oldCompanion, newCompanion);
   } catch (error) {
     console.error(`Error parsing ${oldCompanion.Name}`);
     console.error(error);

--- a/build/wikia/transformers/transformCompanion.mjs
+++ b/build/wikia/transformers/transformCompanion.mjs
@@ -16,9 +16,7 @@ export default async (oldCompanion, imageUrls) => {
 
     newCompanion = {
       name: Name,
-      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(
-        Name.replace(/\s/g, '_').replace('_Prime', '/Prime')
-      )}`,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_').replace('_Prime', '/Prime'))}`,
       mr: Mastery || 0,
       polarities: Polarities,
       stamina: Stamina,

--- a/build/wikia/transformers/transformMod.mjs
+++ b/build/wikia/transformers/transformMod.mjs
@@ -9,7 +9,7 @@ export default async (oldMod, imageUrls) => {
 
     newMod = {
       name: Name,
-      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
       transmutable: Transmutable,
       introduced: Introduced,
       thumbnail: imageUrls?.[Image],

--- a/build/wikia/transformers/transformVersion.mjs
+++ b/build/wikia/transformers/transformVersion.mjs
@@ -10,7 +10,7 @@ export default async (oldVersion) => {
 
     newVersion = {
       name: Name,
-      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(Link.replace(/\s/g, '_'))}`,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Link.replace(/\s/g, '_'))}`,
       aliases: Aliases,
       parent: Parent,
       date: Date,

--- a/build/wikia/transformers/transformWarframe.mjs
+++ b/build/wikia/transformers/transformWarframe.mjs
@@ -39,9 +39,7 @@ export default async (oldFrame, imageUrls, blueprints) => {
 
     newFrame = {
       name: Name,
-      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(
-        Name.replace(/\s/g, '_').replace('_Prime', '/Prime')
-      )}`,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_').replace('_Prime', '/Prime'))}`,
       auraPolarity: AuraPolarity,
       conclave: Conclave,
       mr: Mastery || 0,

--- a/build/wikia/transformers/transformWeapon.mjs
+++ b/build/wikia/transformers/transformWeapon.mjs
@@ -207,7 +207,7 @@ export default (oldWeapon, imageUrls, blueprints) => {
     newWeapon = {
       regex: `^${Name.toLowerCase().replace(/\s/g, '\\s')}$`,
       name: Name,
-      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
       mr: Mastery || 0,
       type: Class || Type,
       riven_disposition: Disposition,

--- a/build/wikia/transformers/transformerArchwing.mjs
+++ b/build/wikia/transformers/transformerArchwing.mjs
@@ -18,9 +18,7 @@ export default async (oldWings, imageUrls) => {
 
     newWings = {
       name: Name,
-      url: `https://warframe.fandom.com/wiki/${encodeURIComponent(
-        Name.replace(/\s/g, '_').replace('_Prime', '/Prime')
-      )}`,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_').replace('_Prime', '/Prime'))}`,
       mr: Mastery || 0,
       polarities: Polarities,
       sprint: Sprint,

--- a/index.d.ts
+++ b/index.d.ts
@@ -701,7 +701,17 @@ declare module 'warframe-items' {
 
   type Noise = 'Alarming' | 'Silent';
 
-  type Polarity = 'aura' | 'madurai' | 'naramon' | 'penjaga' | 'umbra' | 'unairu' | 'universal' | 'vazarin' | 'zenurik';
+  type Polarity =
+    | 'aura'
+    | 'madurai'
+    | 'naramon'
+    | 'penjaga'
+    | 'umbra'
+    | 'unairu'
+    | 'universal'
+    | 'vazarin'
+    | 'zenurik'
+    | 'any';
 
   type Projectile = 'Discharge' | 'Hitscan' | 'Projectile' | 'Thrown';
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
- feat: migrate fandom wikia links to the official Warframe wiki
- fix: archwing and companion wiki data wasn't being added 
---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded in-game data processing now includes additional categories for items such as Sentinels and Archwings.
  - Introduced a new "any" option for polarity selection.

- **Chores**
  - Updated various data source endpoints and URL references to ensure improved accuracy and consistency in information retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->