### PR TITLE
feat(scraper): add ArcaneScraper and transformer for arcanes

### DIFF
--- a/build/scraper.mjs
+++ b/build/scraper.mjs
@@ -4,6 +4,7 @@ import { Generator as RelicGenerator } from '@wfcd/relics';
 import patchlogs from 'warframe-patchlogs';
 
 import Progress from './progress.mjs';
+import ArcaneScraper from './wikia/scrapers/ArcaneScraper.mjs';
 import ArchwingScraper from './wikia/scrapers/ArchwingScraper.mjs';
 import CompanionScraper from './wikia/scrapers/CompanionScraper.mjs';
 import ModScraper from './wikia/scrapers/ModScraper.mjs';
@@ -207,13 +208,14 @@ class Scraper {
    * @property {Array<WikiaMods>} mods
    * @property {Array<WikiaVersions>} versions
    * @property {Array<WikiaDucats>} ducats
+   * @property {Array<WikiaArcanes>} arcanes
    */
   /**
    * Get additional data from wikia if it's not provided in the API
    * @returns {WikiaData}
    */
   async fetchWikiaData() {
-    const bar = new Progress('Fetching Wikia Data', 7);
+    const bar = new Progress('Fetching Wikia Data', 8);
     const ducats = [];
     const ducatsWikia = await get('https://wiki.warframe.com/w/Ducats/Prices/All', true);
     const $ = load(ducatsWikia);
@@ -231,6 +233,8 @@ class Scraper {
     bar.tick();
     const mods = await new ModScraper().scrape();
     bar.tick();
+    const arcanes = await new ArcaneScraper().scrape();
+    bar.tick();
     const versions = await new VersionScraper().scrape();
     bar.tick();
     const archwings = await new ArchwingScraper().scrape();
@@ -246,6 +250,7 @@ class Scraper {
       ducats,
       archwings,
       companions,
+      arcanes,
     };
   }
 

--- a/build/tradable.mjs
+++ b/build/tradable.mjs
@@ -1,6 +1,21 @@
 const builtUntradable = ['Warframe', 'Throwing', 'Shotgun', 'Rifle', 'Pistol', 'Melee', 'Sword And Shield'];
 const tradableConditions = (item) => !(builtUntradable.includes(item.type) && item.name.match(/Prime/gi));
 
+const tradableArcanes = [
+  'Arcane',
+  'Primary Arcane',
+  'Secondary Arcane',
+  'Melee Arcane',
+  'Amp Arcane',
+  'Zaw Arcane',
+  'Kitgun Arcane',
+  'Shotgun Arcane',
+  'Sniper Arcane',
+  'Operator Arcane',
+  'Bow Arcane',
+  'Warframe Arcane',
+];
+
 const tradableMods = [
   'Arch-Melee Mod',
   'Archwing Mod',
@@ -17,7 +32,16 @@ const tradableMods = [
   'Stance Mod',
   'Warframe Mod',
 ];
-const tradableTypes = ['Arcane', 'Captura', 'Cut Gem', 'Fish', 'Focus Lens', 'Relic', 'Upgrades', ...tradableMods];
+const tradableTypes = [
+  'Captura',
+  'Cut Gem',
+  'Fish',
+  'Focus Lens',
+  'Relic',
+  'Upgrades',
+  ...tradableArcanes,
+  ...tradableMods,
+];
 const untradableTypes = [
   'Color Palette',
   'Exalted Weapon',

--- a/build/wikia/WikiaDataScraper.mjs
+++ b/build/wikia/WikiaDataScraper.mjs
@@ -180,7 +180,6 @@ export default class WikiaDataScraper {
           things.push(transformedThing);
         })
       );
-
       things.sort(nameCompare);
     } catch (e) {
       console.error(e.stack);

--- a/build/wikia/scrapers/ArcaneScraper.mjs
+++ b/build/wikia/scrapers/ArcaneScraper.mjs
@@ -1,0 +1,8 @@
+import WikiaDataScraper from '../WikiaDataScraper.mjs';
+import transformArcanes from '../transformers/transformArcanes.mjs';
+
+export default class ArcaneScraper extends WikiaDataScraper {
+  constructor() {
+    super('https://wiki.warframe.com/w/Module:Arcane/data?action=edit', 'Arcane', transformArcanes);
+  }
+}

--- a/build/wikia/transformers/transformArcanes.mjs
+++ b/build/wikia/transformers/transformArcanes.mjs
@@ -1,0 +1,23 @@
+export default async (oldArcane, imageUrls) => {
+  let newArcane;
+  if (!oldArcane || !oldArcane.Name) {
+    return undefined;
+  }
+
+  try {
+    const { Image, Name, Transmutable, Introduced, Type } = oldArcane;
+
+    newArcane = {
+      name: Name,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
+      transmutable: Transmutable,
+      introduced: Introduced,
+      type: Type,
+      thumbnail: imageUrls?.[Image],
+    };
+  } catch (error) {
+    console.error(`Error parsing ${oldArcane.Name}`);
+    console.error(error);
+  }
+  return newArcane;
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -249,7 +249,7 @@ declare module 'warframe-items' {
     patchlogs?: PatchLog[];
     rarity?: Rarity;
     tradable: true;
-    type: 'Arcane';
+    type: 'Arcane' | `${ArcaneType} Arcane`;
   }
   interface StanceMod extends Omit<Mod, 'levelStats'> {
     type: 'Stance Mod';
@@ -299,6 +299,20 @@ declare module 'warframe-items' {
     | 'Peculiar'
     | 'Plexus'
     | 'Posture';
+
+  type ArcaneType =
+    | 'Primary'
+    | 'Secondary'
+    | 'Melee'
+    | 'Warframe'
+    | 'Amp'
+    | 'Operator'
+    | 'Zaw'
+    | 'Kitgun'
+    | 'Bow'
+    | 'Shotgun'
+    | 'Sniper';
+
   interface Mod extends MinimalItem, WikiaItem, Droppable {
     baseDrain: number;
     category: 'Mods';


### PR DESCRIPTION
Introduce a new scraper class `ArcaneScraper` and a corresponding transformer `transformArcanes` to handle scraping and transforming arcane data from the Warframe wiki.

### What did you fix? <!-- provide a description or issue closes statement -->

Add the ability for Arcanes to have types corresponding to the Item it slots onto by introducing a wiki scraper for them.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **NO**
- Does this introduce opinionated data formatting or manual data entry? **NO**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **NO**
- Have I run the linter? **YES**
- Is is a bug fix, feature request, or enhancement? **Feature/Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive arcane data integration that enriches item details with updated information and improved classification.
  - Enhanced data fetching to include arcane-specific properties for a more complete and reliable display of items.
  - Added a new scraper specifically for Arcane data to streamline data collection.
  - Implemented new methods to handle and transform arcane data effectively.
  - Expanded the range of tradable item types to include various Arcane categories.
  - Updated the Arcane interface to allow for a wider variety of arcane item types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->