### PR TITLE
fix: update to new ws-data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10091,15 +10091,15 @@
       }
     },
     "warframe-patchlogs": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/warframe-patchlogs/-/warframe-patchlogs-2.77.0.tgz",
-      "integrity": "sha512-U9jwpj/Tr1RLHYJMKsvTlavP18Ti5gGI0PX+Mal2v5xIdH6/WEPuXWZ0bl9tONGvfbiKpESaRICyumpnnVgzBw==",
+      "version": "2.76.0",
+      "resolved": "https://registry.npmjs.org/warframe-patchlogs/-/warframe-patchlogs-2.76.0.tgz",
+      "integrity": "sha512-mzEB9jcrTuZ7fQB4Yu5raR0BTSUiu0kiM9v2q/vP8ir/NBXYCFRJMKt6+tdo1K7PuRS8Bchb/knsuejEpb0yOA==",
       "dev": true
     },
     "warframe-worldstate-data": {
-      "version": "2.24.6",
-      "resolved": "https://registry.npmjs.org/warframe-worldstate-data/-/warframe-worldstate-data-2.24.6.tgz",
-      "integrity": "sha512-DGOsUYry3YUYHixpYRoEzqA4ThDSJir40QuZQOaz1TAXnoN+rTAju283yors+2ArvivOyNZo6149GiljEM7Y2g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warframe-worldstate-data/-/warframe-worldstate-data-3.0.0.tgz",
+      "integrity": "sha512-trcdCce+iNjmPnBN+VUd44yO1heVVJxavTq+U8wErrjjjKxv93QVxNiyB9V3lsD8R8FPkA3ZWjEM8p9bHKvHPw==",
       "peer": true
     },
     "webidl-conversions": {
@@ -10382,7 +10382,7 @@
         "warframe-patchlogs": "^2.77.0"
       },
       "peerDependencies": {
-        "warframe-worldstate-data": "^2.24"
+        "warframe-worldstate-data": "^3.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -24414,9 +24414,9 @@
       }
     },
     "node_modules/warframe-worldstate-data": {
-      "version": "2.24.6",
-      "resolved": "https://registry.npmjs.org/warframe-worldstate-data/-/warframe-worldstate-data-2.24.6.tgz",
-      "integrity": "sha512-DGOsUYry3YUYHixpYRoEzqA4ThDSJir40QuZQOaz1TAXnoN+rTAju283yors+2ArvivOyNZo6149GiljEM7Y2g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warframe-worldstate-data/-/warframe-worldstate-data-3.0.0.tgz",
+      "integrity": "sha512-trcdCce+iNjmPnBN+VUd44yO1heVVJxavTq+U8wErrjjjKxv93QVxNiyB9V3lsD8R8FPkA3ZWjEM8p9bHKvHPw==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "warframe-patchlogs": "^2.77.0"
   },
   "peerDependencies": {
-    "warframe-worldstate-data": "^2.24"
+    "warframe-worldstate-data": "^3.0.0"
   }
 }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
updates warframe-worldstate-data to v3

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the required version of a peer dependency to ensure compatibility with newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->