### PR TITLE
fix: relic refinement drop rates

### DIFF
--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -365,6 +365,43 @@ const test = (base) => {
         });
       });
     });
+    describe('relics', async () => {
+      it('should have correct drop rates for each refinement level', async () => {
+        const relics = await wrapConstr({ category: ['Relics'] });
+
+        // Expected patterns for each refinement level
+        const expectedPatterns = {
+          Intact: { 25.33: 3, 11: 2, 2: 1 },
+          Exceptional: { 23.33: 3, 13: 2, 4: 1 },
+          Flawless: { 20: 3, 17: 2, 6: 1 },
+          Radiant: { 16.67: 3, 20: 2, 10: 1 },
+        };
+
+        Object.entries(expectedPatterns).forEach(([level, expected]) => {
+          const relicsAtLevel = relics.filter((r) => r.name.endsWith(level));
+          relicsAtLevel.forEach((relic) => {
+            // BUG: Skip Axi S19 - has no rewards (doesn't exist in game)
+            if (!relic.rewards || relic.rewards.length === 0) {
+              return;
+            }
+            // Group rewards by percentage
+            const chanceGroups = {};
+            relic.rewards.forEach((reward) => {
+              if (!chanceGroups[reward.chance]) {
+                chanceGroups[reward.chance] = 0;
+              }
+              chanceGroups[reward.chance] += 1;
+            });
+
+            assert.deepStrictEqual(
+              chanceGroups,
+              expected,
+              `${relic.name} should have exact distribution: ${JSON.stringify(expected)}`
+            );
+          });
+        });
+      });
+    });
   });
 };
 


### PR DESCRIPTION
### What did you fix?
fixes #602

> **Note:** First ever OSS contribution, developed with AI assistance. Open to all feedback and criticism!

All relic refinement levels (Intact, Exceptional, Flawless, Radiant) were showing identical drop rates (e.g. 2% for rare items) instead of their refinement-specific rates.

The bug was in the [`addRelics`](https://github.com/WFCD/warframe-items/blob/master/build/parser.mjs#L1088) function which was using reward data from [`@wfcd/relics`](https://github.com/WFCD/warframe-relic-data) package (which only contains Intact/base drop rates) instead of the [drops API](https://drops.warframestat.us/data/all.slim.json) (which has accurate refinement-specific data).

---

### Reproduction steps
1. Clone master branch and run `npm install && npm run build -- --force`
2. Open generated `data/json/Relics.json`
3. Find "Axi A1 Intact" - rare item shows 2% chance
4. Find "Axi A1 Radiant" - rare item also shows 2% chance (should be 10%)
5. This affects all relics at all refinement levels

---

### Evidence/screenshot/link to line

- **Code fix:**
  - [build/parser.mjs:202](https://github.com/BUSTheid/warframe-items/blob/fix/relic-refinement-drop-rates/build/parser.mjs#L202) - Pass drops data to `addRelics`
  - [build/parser.mjs:1074](https://github.com/BUSTheid/warframe-items/blob/fix/relic-refinement-drop-rates/build/parser.mjs#L1074) - Update function signature
  - [build/parser.mjs:1090-1117](https://github.com/BUSTheid/warframe-items/blob/fix/relic-refinement-drop-rates/build/parser.mjs#L1090-L1117) - New rewards logic using drops API
- **Test added:** [test/index.spec.mjs:368-403](https://github.com/BUSTheid/warframe-items/blob/fix/relic-refinement-drop-rates/test/index.spec.mjs#L368-L403)
- **Before:** All<sup>*</sup> refinement levels had identical distribution patterns (all showing Intact rates: 25.33%, 11%, 2%)
- **After:** Each refinement level has its correct distribution pattern:
  - Intact:
    - 3 items @ 25.33%,
    - 2 @ 11%,
    - 1 @ 2%
  - Exceptional:
    - 3 items @ 23.33%,
    - 2 @ 13%,
    - 1 @ 4%
  - Flawless:
    - 3 items @ 20%,
    - 2 @ 17%,
    - 1 @ 6%
  - Radiant:
    - 3 items @ 16.67%,
    - 2 @ 20%,
    - 1 @ 10%

> **<sup>*</sup>Note:** The test validates drop rate distribution patterns across all refinement levels. However, 2 workarounds were necessary for existing data issues unrelated to this fix:
> 1. **Axi S19 Relic** ([test/index.spec.mjs:383-386](https://github.com/BUSTheid/warframe-items/blob/fix/relic-refinement-drop-rates/test/index.spec.mjs#L383-L386)): Has no rewards in the data, likely because this relic doesn't exist in the actual game. The test skips empty reward arrays.
> 2. **I fixed this bug, which I accidentally introduced!** ~~**Meso D1 Relic** ([test/index.spec.mjs:388-391](https://github.com/BUSTheid/warframe-items/blob/fix/relic-refinement-drop-rates/test/index.spec.mjs#L388-L391)): Contains two "2X Forma Blueprint" entries that should have different drop chances (25.33% and 11% in upstream drops API), but both end up with the same chance due to what appears to be an item deduplication issue in the parser. This causes the distribution pattern to differ from expected. The test skips this relic to avoid false failures.~~

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relic rewards are now enriched with drop-rate data, merging chance values from drop tables into displayed rewards.

* **Bug Fixes**
  * Relic rewards now display more accurate drop chances based on refinement levels.

* **Tests**
  * Added test coverage to validate relic drop rate distributions across refinement levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->