### PR TITLE
feat: artifact upload step in build and static workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,3 +53,7 @@ jobs:
           commit_user_name: wfcd-bot-boi
           commit_user_email: botboi@warframestat.us
           commit_author: wfcd-bot-boi <botboi@warframestat.us>
+      - uses: actions/upload-artifact@v4
+        with:
+          name: data
+          path: ./data/json/All.json

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -58,6 +58,10 @@ jobs:
           PROXY_SOCKS5_HOST: ${{ secrets.PROXY_SOCKS5_HOST }}
           PROXY_SOCKS5_PORT: ${{ secrets.PROXY_SOCKS5_PORT }}
           PROXY_HTTPS_STRING: ${{ secrets.PROXY_HTTPS_STRING }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: data
+          path: ./data/json/All.json
   types:
     name: Type Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
In the build workflow (example https://github.com/AyAyEm/warframe-items/actions/runs/19793990428) is for future use when we stop tracking the data with git, in the static workflow (example https://github.com/AyAyEm/warframe-items/actions/runs/19794387611/job/56712597550?pr=1) is for when we can't rely on people building their own data and for saving time on reviews where we need to know the data, for the two i only used the All.json, which files we need to upload are up for debate and i would appreciate the input on that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline to automatically upload build artifacts as part of the deployment workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->