### PR TITLE
fix: regex not matching non PVP strikes

### DIFF
--- a/config/masterableCategories.json
+++ b/config/masterableCategories.json
@@ -1,5 +1,5 @@
 {
-  "regex": "^((?=.*(Amp|Modular))|)(?=.*Barrel).*$|^(?=.*Pet)(?=.*Head).*$|PetPowerSuit|\/(?!PvPVariant)(?:\\w+)?Tip\\w+$|^(?=.*Hoverboard)(?=.*Deck).*$",
+  "regex": "^(?=.*(Amp|Modular))(?=.*Barrel).*$|^(?=.*Pet)(?=.*Head).*$|PetPowerSuit|\/(?!PvPVariant)(?:\\w+)?Tip\\w+$|^(?=.*Hoverboard)(?=.*Deck).*$",
   "categories": [
     "Archwing",
     "Arch-Melee",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
It should match all zaw strikes *EXCEPT* PvP variants which are (to my understanding) just a way for the game to easily switch stats in-game

closes #823 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of item categorization with refined matching logic for equipment variants and combinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->