### PR TITLE
fix: preserve i18n and versions in filter method

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,8 +192,7 @@ module.exports = class Items extends Array {
   map(fn) {
     const a = [];
     for (const el of this) a.push(fn(el));
-    if (this.i18n) a.i18n = this.i18n;
-    a.versions = this.versions;
+
     return a;
   }
 };

--- a/index.js
+++ b/index.js
@@ -165,6 +165,11 @@ module.exports = class Items extends Array {
     for (const el of this) {
       if (fn(el)) A.push(el);
     }
+    if (this.i18n) {
+      const filteredNames = new Set(A.map((el) => el.uniqueName));
+      A.i18n = Object.fromEntries(Object.entries(this.i18n).filter(([key]) => filteredNames.has(key)));
+    }
+    A.versions = this.versions;
     return A;
   }
 
@@ -176,7 +181,8 @@ module.exports = class Items extends Array {
   map(fn) {
     const a = [];
     for (const el of this) a.push(fn(el));
-
+    a.i18n = this.i18n;
+    a.versions = this.versions;
     return a;
   }
 };

--- a/index.js
+++ b/index.js
@@ -161,14 +161,25 @@ module.exports = class Items extends Array {
    */
   filter(fn) {
     const A = [];
+    const filteredNames = this.i18n ? new Set() : null;
 
     for (const el of this) {
-      if (fn(el)) A.push(el);
+      if (fn(el)) {
+        A.push(el);
+        if (filteredNames) filteredNames.add(el.uniqueName);
+      }
     }
-    if (this.i18n) {
-      const filteredNames = new Set(A.map((el) => el.uniqueName));
-      A.i18n = Object.fromEntries(Object.entries(this.i18n).filter(([key]) => filteredNames.has(key)));
+
+    if (filteredNames) {
+      const filteredI18n = {};
+      for (const uniqueName of filteredNames) {
+        if (Object.prototype.hasOwnProperty.call(this.i18n, uniqueName)) {
+          filteredI18n[uniqueName] = this.i18n[uniqueName];
+        }
+      }
+      A.i18n = filteredI18n;
     }
+
     A.versions = this.versions;
     return A;
   }
@@ -181,7 +192,7 @@ module.exports = class Items extends Array {
   map(fn) {
     const a = [];
     for (const el of this) a.push(fn(el));
-    a.i18n = this.i18n;
+    if (this.i18n) a.i18n = this.i18n;
     a.versions = this.versions;
     return a;
   }

--- a/index.mjs
+++ b/index.mjs
@@ -164,6 +164,11 @@ export default class Items extends Array {
     for (const el of this) {
       if (fn(el)) A.push(el);
     }
+    if (this.i18n) {
+      const filteredNames = new Set(A.map((el) => el.uniqueName));
+      A.i18n = Object.fromEntries(Object.entries(this.i18n).filter(([key]) => filteredNames.has(key)));
+    }
+    A.versions = this.versions;
     return A;
   }
 
@@ -175,7 +180,8 @@ export default class Items extends Array {
   map(fn) {
     const a = [];
     for (const el of this) a.push(fn(el));
-
+    a.i18n = this.i18n;
+    a.versions = this.versions;
     return a;
   }
 }

--- a/index.mjs
+++ b/index.mjs
@@ -191,8 +191,7 @@ export default class Items extends Array {
   map(fn) {
     const a = [];
     for (const el of this) a.push(fn(el));
-    if (this.i18n) a.i18n = this.i18n;
-    a.versions = this.versions;
+
     return a;
   }
 }

--- a/index.mjs
+++ b/index.mjs
@@ -160,27 +160,38 @@ export default class Items extends Array {
    */
   filter(fn) {
     const A = [];
+    const filteredNames = this.i18n ? new Set() : null;
 
     for (const el of this) {
-      if (fn(el)) A.push(el);
+      if (fn(el)) {
+        A.push(el);
+        if (filteredNames) filteredNames.add(el.uniqueName);
+      }
     }
-    if (this.i18n) {
-      const filteredNames = new Set(A.map((el) => el.uniqueName));
-      A.i18n = Object.fromEntries(Object.entries(this.i18n).filter(([key]) => filteredNames.has(key)));
+
+    if (filteredNames) {
+      const filteredI18n = {};
+      for (const uniqueName of filteredNames) {
+        if (Object.prototype.hasOwnProperty.call(this.i18n, uniqueName)) {
+          filteredI18n[uniqueName] = this.i18n[uniqueName];
+        }
+      }
+      A.i18n = filteredI18n;
     }
+
     A.versions = this.versions;
     return A;
   }
 
   /**
-   * @Override Array.prototype.filter
+   * @Override Array.prototype.map
    *
    * See filter override
    */
   map(fn) {
     const a = [];
     for (const el of this) a.push(fn(el));
-    a.i18n = this.i18n;
+    if (this.i18n) a.i18n = this.i18n;
     a.versions = this.versions;
     return a;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10253,18 +10253,20 @@
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
       "version": "1.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -10274,15 +10276,17 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -10296,9 +10300,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "9.4.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
@@ -10344,9 +10349,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "10.8.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/map-workspaces": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -10363,9 +10369,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -10375,9 +10382,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "7.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
@@ -10394,9 +10402,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-bundled": "^5.0.0",
         "npm-normalize-package-bin": "^5.0.0"
@@ -10410,9 +10419,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "5.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/name-from-folder": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -10425,9 +10435,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "9.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cacache": "^20.0.0",
         "json-parse-even-better-errors": "^5.0.0",
@@ -10441,27 +10452,30 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "7.0.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "glob": "^13.0.0",
@@ -10477,9 +10491,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "which": "^6.0.0"
       },
@@ -10489,9 +10504,10 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "postcss-selector-parser": "^7.0.0"
       },
@@ -10501,18 +10517,20 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "10.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/node-gyp": "^5.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -10526,9 +10544,10 @@
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0"
       },
@@ -10538,27 +10557,30 @@
     },
     "node_modules/npm/node_modules/@sigstore/core": {
       "version": "3.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.5.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "4.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
@@ -10573,9 +10595,10 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "4.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
         "tuf-js": "^4.1.0"
@@ -10586,9 +10609,10 @@
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
         "@sigstore/core": "^3.1.0",
@@ -10600,18 +10624,20 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "4.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
         "minimatch": "^10.1.1"
@@ -10622,48 +10648,54 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "4.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "cmd-shim": "^8.0.0",
         "npm-normalize-package-bin": "^5.0.0",
@@ -10677,9 +10709,10 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.20"
       },
@@ -10689,9 +10722,10 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "5.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -10701,9 +10735,10 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "20.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^5.0.0",
         "fs-minipass": "^3.0.0",
@@ -10722,9 +10757,10 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.6.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -10734,16 +10770,17 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "3.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.4.0",
-      "extraneous": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10752,42 +10789,47 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "5.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "8.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -10797,9 +10839,10 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -10814,42 +10857,47 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "8.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -10859,9 +10907,10 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "13.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -10876,15 +10925,17 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "9.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
@@ -10894,15 +10945,17 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -10913,9 +10966,10 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -10926,9 +10980,11 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.7.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -10942,9 +10998,10 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "8.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.0.3"
       },
@@ -10954,18 +11011,20 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "8.2.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^7.0.0",
         "npm-package-arg": "^13.0.0",
@@ -10980,18 +11039,20 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "10.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "6.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "cidr-regex": "^5.0.1"
       },
@@ -11001,57 +11062,64 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
-      "extraneous": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "10.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-package-arg": "^13.0.0",
         "npm-registry-fetch": "^19.0.0"
@@ -11062,9 +11130,10 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "8.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.4.2",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -11081,9 +11150,10 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "10.2.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/arborist": "^9.4.2",
@@ -11104,9 +11174,10 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "7.0.19",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.4.2"
       },
@@ -11116,9 +11187,10 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "8.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^19.0.0"
@@ -11129,9 +11201,10 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "9.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^9.4.2",
         "@npmcli/run-script": "^10.0.0",
@@ -11144,9 +11217,10 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "11.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/package-json": "^7.0.0",
         "ci-info": "^4.0.0",
@@ -11163,9 +11237,10 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "9.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^19.0.0"
       },
@@ -11175,9 +11250,10 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "8.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "aproba": "^2.0.0",
         "npm-registry-fetch": "^19.0.0"
@@ -11188,9 +11264,10 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "8.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/git": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
@@ -11204,18 +11281,20 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "11.2.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "15.0.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
@@ -11236,9 +11315,10 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "10.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
@@ -11251,18 +11331,20 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -11272,9 +11354,10 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "5.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^2.0.0",
@@ -11289,9 +11372,10 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -11301,9 +11385,10 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -11313,15 +11398,17 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -11331,9 +11418,10 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -11343,15 +11431,17 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -11361,9 +11451,10 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -11373,33 +11464,37 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "3.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "12.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -11421,9 +11516,10 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "9.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "abbrev": "^4.0.0"
       },
@@ -11436,18 +11532,20 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "7.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-normalize-package-bin": "^5.0.0"
       },
@@ -11457,9 +11555,10 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "8.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "semver": "^7.1.1"
       },
@@ -11469,18 +11568,20 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "13.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^9.0.0",
         "proc-log": "^6.0.0",
@@ -11493,9 +11594,10 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "10.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ignore-walk": "^8.0.0",
         "proc-log": "^6.0.0"
@@ -11506,9 +11608,10 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "11.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-install-checks": "^8.0.0",
         "npm-normalize-package-bin": "^5.0.0",
@@ -11521,9 +11624,10 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "12.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
         "proc-log": "^6.0.0"
@@ -11534,9 +11638,10 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "19.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@npmcli/redact": "^4.0.0",
         "jsonparse": "^1.3.1",
@@ -11553,18 +11658,20 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11574,9 +11681,10 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "21.5.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/git": "^7.0.0",
@@ -11605,9 +11713,10 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "5.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "json-parse-even-better-errors": "^5.0.0",
         "just-diff": "^6.0.0",
@@ -11619,9 +11728,10 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "2.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -11635,9 +11745,10 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11648,45 +11759,50 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "6.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "read": "^5.0.0"
       },
@@ -11696,17 +11812,19 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/npm/node_modules/read": {
       "version": "5.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "mute-stream": "^3.0.0"
       },
@@ -11716,24 +11834,28 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "6.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11743,9 +11865,10 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -11755,9 +11878,10 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "4.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
         "@sigstore/core": "^3.1.0",
@@ -11772,9 +11896,10 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -11782,9 +11907,10 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -11796,9 +11922,10 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -11810,15 +11937,17 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "CC-BY-3.0"
+      "license": "CC-BY-3.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -11826,15 +11955,17 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.23",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "13.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -11844,9 +11975,10 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "10.2.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11856,9 +11988,10 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "7.5.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -11872,21 +12005,24 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "2.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.15",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -11900,9 +12036,10 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -11917,9 +12054,10 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11929,18 +12067,20 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "4.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tufjs/models": "4.1.0",
         "debug": "^4.4.3",
@@ -11952,33 +12092,37 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "4.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/which": {
       "version": "6.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^4.0.0"
       },
@@ -11991,9 +12135,10 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "7.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "signal-exit": "^4.0.1"
       },
@@ -12003,9 +12148,10 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "5.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -23223,12 +23369,14 @@
         "@gar/promise-retry": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@isaacs/fs-minipass": {
           "version": "4.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^7.0.4"
           }
@@ -23236,12 +23384,14 @@
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@npmcli/agent": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "agent-base": "^7.1.0",
             "http-proxy-agent": "^7.0.0",
@@ -23253,7 +23403,8 @@
         "@npmcli/arborist": {
           "version": "9.4.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@isaacs/string-locale-compare": "^1.1.0",
@@ -23294,7 +23445,8 @@
         "@npmcli/config": {
           "version": "10.8.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/map-workspaces": "^5.0.0",
             "@npmcli/package-json": "^7.0.0",
@@ -23309,7 +23461,8 @@
         "@npmcli/fs": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "semver": "^7.3.5"
           }
@@ -23317,7 +23470,8 @@
         "@npmcli/git": {
           "version": "7.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@npmcli/promise-spawn": "^9.0.0",
@@ -23332,7 +23486,8 @@
         "@npmcli/installed-package-contents": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "npm-bundled": "^5.0.0",
             "npm-normalize-package-bin": "^5.0.0"
@@ -23341,7 +23496,8 @@
         "@npmcli/map-workspaces": {
           "version": "5.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/name-from-folder": "^4.0.0",
             "@npmcli/package-json": "^7.0.0",
@@ -23352,7 +23508,8 @@
         "@npmcli/metavuln-calculator": {
           "version": "9.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "cacache": "^20.0.0",
             "json-parse-even-better-errors": "^5.0.0",
@@ -23364,17 +23521,20 @@
         "@npmcli/name-from-folder": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@npmcli/node-gyp": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@npmcli/package-json": {
           "version": "7.0.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/git": "^7.0.0",
             "glob": "^13.0.0",
@@ -23388,7 +23548,8 @@
         "@npmcli/promise-spawn": {
           "version": "9.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "which": "^6.0.0"
           }
@@ -23396,7 +23557,8 @@
         "@npmcli/query": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "postcss-selector-parser": "^7.0.0"
           }
@@ -23404,12 +23566,14 @@
         "@npmcli/redact": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@npmcli/run-script": {
           "version": "10.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/node-gyp": "^5.0.0",
             "@npmcli/package-json": "^7.0.0",
@@ -23421,7 +23585,8 @@
         "@sigstore/bundle": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@sigstore/protobuf-specs": "^0.5.0"
           }
@@ -23429,17 +23594,20 @@
         "@sigstore/core": {
           "version": "3.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@sigstore/protobuf-specs": {
           "version": "0.5.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@sigstore/sign": {
           "version": "4.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@gar/promise-retry": "^1.0.2",
             "@sigstore/bundle": "^4.0.0",
@@ -23452,7 +23620,8 @@
         "@sigstore/tuf": {
           "version": "4.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@sigstore/protobuf-specs": "^0.5.0",
             "tuf-js": "^4.1.0"
@@ -23461,7 +23630,8 @@
         "@sigstore/verify": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@sigstore/bundle": "^4.0.0",
             "@sigstore/core": "^3.1.0",
@@ -23471,12 +23641,14 @@
         "@tufjs/canonical-json": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "@tufjs/models": {
           "version": "4.1.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@tufjs/canonical-json": "2.0.0",
             "minimatch": "^10.1.1"
@@ -23485,32 +23657,38 @@
         "abbrev": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "agent-base": {
           "version": "7.1.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "aproba": {
           "version": "2.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "archy": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "balanced-match": {
           "version": "4.0.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "bin-links": {
           "version": "6.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "cmd-shim": "^8.0.0",
             "npm-normalize-package-bin": "^5.0.0",
@@ -23522,12 +23700,14 @@
         "binary-extensions": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "brace-expansion": {
           "version": "5.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "balanced-match": "^4.0.2"
           }
@@ -23535,7 +23715,8 @@
         "cacache": {
           "version": "20.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/fs": "^5.0.0",
             "fs-minipass": "^3.0.0",
@@ -23552,42 +23733,50 @@
         "chalk": {
           "version": "5.6.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "chownr": {
           "version": "3.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "ci-info": {
           "version": "4.4.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "cidr-regex": {
           "version": "5.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "cmd-shim": {
           "version": "8.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "common-ancestor-path": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "cssesc": {
           "version": "3.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "debug": {
           "version": "4.4.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "ms": "^2.1.3"
           }
@@ -23595,27 +23784,32 @@
         "diff": {
           "version": "8.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "env-paths": {
           "version": "2.2.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "exponential-backoff": {
           "version": "3.1.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "fastest-levenshtein": {
           "version": "1.0.16",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "fs-minipass": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^7.0.3"
           }
@@ -23623,7 +23817,8 @@
         "glob": {
           "version": "13.0.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minimatch": "^10.2.2",
             "minipass": "^7.1.3",
@@ -23633,12 +23828,14 @@
         "graceful-fs": {
           "version": "4.2.11",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "hosted-git-info": {
           "version": "9.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "lru-cache": "^11.1.0"
           }
@@ -23646,12 +23843,14 @@
         "http-cache-semantics": {
           "version": "4.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "http-proxy-agent": {
           "version": "7.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "agent-base": "^7.1.0",
             "debug": "^4.3.4"
@@ -23660,7 +23859,8 @@
         "https-proxy-agent": {
           "version": "7.0.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "agent-base": "^7.1.2",
             "debug": "4"
@@ -23669,7 +23869,9 @@
         "iconv-lite": {
           "version": "0.7.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -23677,7 +23879,8 @@
         "ignore-walk": {
           "version": "8.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minimatch": "^10.0.3"
           }
@@ -23685,12 +23888,14 @@
         "ini": {
           "version": "6.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "init-package-json": {
           "version": "8.2.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/package-json": "^7.0.0",
             "npm-package-arg": "^13.0.0",
@@ -23703,12 +23908,14 @@
         "ip-address": {
           "version": "10.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "is-cidr": {
           "version": "6.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "cidr-regex": "^5.0.1"
           }
@@ -23716,37 +23923,44 @@
         "isexe": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "json-parse-even-better-errors": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "json-stringify-nice": {
           "version": "1.1.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "jsonparse": {
           "version": "1.3.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "just-diff": {
           "version": "6.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "just-diff-apply": {
           "version": "5.5.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "libnpmaccess": {
           "version": "10.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "npm-package-arg": "^13.0.0",
             "npm-registry-fetch": "^19.0.0"
@@ -23755,7 +23969,8 @@
         "libnpmdiff": {
           "version": "8.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/arborist": "^9.4.2",
             "@npmcli/installed-package-contents": "^4.0.0",
@@ -23770,7 +23985,8 @@
         "libnpmexec": {
           "version": "10.2.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@npmcli/arborist": "^9.4.2",
@@ -23789,7 +24005,8 @@
         "libnpmfund": {
           "version": "7.0.19",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/arborist": "^9.4.2"
           }
@@ -23797,7 +24014,8 @@
         "libnpmorg": {
           "version": "8.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^19.0.0"
@@ -23806,7 +24024,8 @@
         "libnpmpack": {
           "version": "9.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/arborist": "^9.4.2",
             "@npmcli/run-script": "^10.0.0",
@@ -23817,7 +24036,8 @@
         "libnpmpublish": {
           "version": "11.1.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/package-json": "^7.0.0",
             "ci-info": "^4.0.0",
@@ -23832,7 +24052,8 @@
         "libnpmsearch": {
           "version": "9.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "npm-registry-fetch": "^19.0.0"
           }
@@ -23840,7 +24061,8 @@
         "libnpmteam": {
           "version": "8.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "aproba": "^2.0.0",
             "npm-registry-fetch": "^19.0.0"
@@ -23849,7 +24071,8 @@
         "libnpmversion": {
           "version": "8.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/git": "^7.0.0",
             "@npmcli/run-script": "^10.0.0",
@@ -23861,12 +24084,14 @@
         "lru-cache": {
           "version": "11.2.7",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "make-fetch-happen": {
           "version": "15.0.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@npmcli/agent": "^4.0.0",
@@ -23885,7 +24110,8 @@
         "minimatch": {
           "version": "10.2.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "brace-expansion": "^5.0.2"
           }
@@ -23893,12 +24119,14 @@
         "minipass": {
           "version": "7.1.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "minipass-collect": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^7.0.3"
           }
@@ -23906,7 +24134,8 @@
         "minipass-fetch": {
           "version": "5.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "iconv-lite": "^0.7.2",
             "minipass": "^7.0.3",
@@ -23917,7 +24146,8 @@
         "minipass-flush": {
           "version": "1.0.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^3.0.0"
           },
@@ -23925,7 +24155,8 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "peer": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -23933,14 +24164,16 @@
             "yallist": {
               "version": "4.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "peer": true
             }
           }
         },
         "minipass-pipeline": {
           "version": "1.2.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^3.0.0"
           },
@@ -23948,7 +24181,8 @@
             "minipass": {
               "version": "3.3.6",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "peer": true,
               "requires": {
                 "yallist": "^4.0.0"
               }
@@ -23956,14 +24190,16 @@
             "yallist": {
               "version": "4.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "peer": true
             }
           }
         },
         "minipass-sized": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^7.1.2"
           }
@@ -23971,7 +24207,8 @@
         "minizlib": {
           "version": "3.1.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^7.1.2"
           }
@@ -23979,22 +24216,26 @@
         "ms": {
           "version": "2.1.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "mute-stream": {
           "version": "3.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "negotiator": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "node-gyp": {
           "version": "12.2.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "env-paths": "^2.2.0",
             "exponential-backoff": "^3.1.1",
@@ -24011,7 +24252,8 @@
         "nopt": {
           "version": "9.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "abbrev": "^4.0.0"
           }
@@ -24019,12 +24261,14 @@
         "npm-audit-report": {
           "version": "7.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "npm-bundled": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "npm-normalize-package-bin": "^5.0.0"
           }
@@ -24032,7 +24276,8 @@
         "npm-install-checks": {
           "version": "8.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "semver": "^7.1.1"
           }
@@ -24040,12 +24285,14 @@
         "npm-normalize-package-bin": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "npm-package-arg": {
           "version": "13.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "hosted-git-info": "^9.0.0",
             "proc-log": "^6.0.0",
@@ -24056,7 +24303,8 @@
         "npm-packlist": {
           "version": "10.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "ignore-walk": "^8.0.0",
             "proc-log": "^6.0.0"
@@ -24065,7 +24313,8 @@
         "npm-pick-manifest": {
           "version": "11.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "npm-install-checks": "^8.0.0",
             "npm-normalize-package-bin": "^5.0.0",
@@ -24076,7 +24325,8 @@
         "npm-profile": {
           "version": "12.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "npm-registry-fetch": "^19.0.0",
             "proc-log": "^6.0.0"
@@ -24085,7 +24335,8 @@
         "npm-registry-fetch": {
           "version": "19.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@npmcli/redact": "^4.0.0",
             "jsonparse": "^1.3.1",
@@ -24100,17 +24351,20 @@
         "npm-user-validate": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "p-map": {
           "version": "7.0.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "pacote": {
           "version": "21.5.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@gar/promise-retry": "^1.0.0",
             "@npmcli/git": "^7.0.0",
@@ -24134,7 +24388,8 @@
         "parse-conflict-json": {
           "version": "5.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "json-parse-even-better-errors": "^5.0.0",
             "just-diff": "^6.0.0",
@@ -24144,7 +24399,8 @@
         "path-scurry": {
           "version": "2.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "lru-cache": "^11.0.0",
             "minipass": "^7.1.2"
@@ -24153,7 +24409,8 @@
         "postcss-selector-parser": {
           "version": "7.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
@@ -24162,27 +24419,32 @@
         "proc-log": {
           "version": "6.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "proggy": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "promise-all-reject-late": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "promise-call-limit": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "promzard": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "read": "^5.0.0"
           }
@@ -24190,12 +24452,14 @@
         "qrcode-terminal": {
           "version": "0.12.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "read": {
           "version": "5.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "mute-stream": "^3.0.0"
           }
@@ -24203,27 +24467,33 @@
         "read-cmd-shim": {
           "version": "6.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "semver": {
           "version": "7.7.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "signal-exit": {
           "version": "4.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "sigstore": {
           "version": "4.1.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@sigstore/bundle": "^4.0.0",
             "@sigstore/core": "^3.1.0",
@@ -24236,12 +24506,14 @@
         "smart-buffer": {
           "version": "4.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "socks": {
           "version": "2.8.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "ip-address": "^10.0.1",
             "smart-buffer": "^4.2.0"
@@ -24250,7 +24522,8 @@
         "socks-proxy-agent": {
           "version": "8.0.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "agent-base": "^7.1.2",
             "debug": "^4.3.4",
@@ -24260,12 +24533,14 @@
         "spdx-exceptions": {
           "version": "2.5.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "spdx-expression-parse": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -24274,12 +24549,14 @@
         "spdx-license-ids": {
           "version": "3.0.23",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "ssri": {
           "version": "13.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "minipass": "^7.0.3"
           }
@@ -24287,12 +24564,14 @@
         "supports-color": {
           "version": "10.2.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "tar": {
           "version": "7.5.11",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",
             "chownr": "^3.0.0",
@@ -24304,17 +24583,20 @@
         "text-table": {
           "version": "0.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "tiny-relative-date": {
           "version": "2.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "tinyglobby": {
           "version": "0.2.15",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "fdir": "^6.5.0",
             "picomatch": "^4.0.3"
@@ -24323,25 +24605,29 @@
             "fdir": {
               "version": "6.5.0",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "peer": true,
               "requires": {}
             },
             "picomatch": {
               "version": "4.0.3",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "peer": true
             }
           }
         },
         "treeverse": {
           "version": "3.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "tuf-js": {
           "version": "4.1.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "@tufjs/models": "4.1.0",
             "debug": "^4.4.3",
@@ -24351,22 +24637,26 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "validate-npm-package-name": {
           "version": "7.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "walk-up-path": {
           "version": "4.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         },
         "which": {
           "version": "6.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "isexe": "^4.0.0"
           }
@@ -24374,7 +24664,8 @@
         "write-file-atomic": {
           "version": "7.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "peer": true,
           "requires": {
             "signal-exit": "^4.0.1"
           }
@@ -24382,7 +24673,8 @@
         "yallist": {
           "version": "5.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "peer": true
         }
       }
     },

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -348,13 +348,22 @@ const test = (base) => {
       assert.deepStrictEqual(mapped.versions, items.versions, 'map should preserve versions');
     });
     it('should filter i18n entries to only matched items', async () => {
-      const targetUniqueName = '/Lotus/Types/Friendly/Pets/ZanukaPets/ZanukaPetParts/ZanukaPetPartHeadB';
       const items = await wrapConstr({ category: ['Pets'], i18n: ['es'] });
+      const targetUniqueName = items[0]?.uniqueName;
       const filtered = items.filter((i) => i.uniqueName === targetUniqueName);
       assert.strictEqual(filtered.length, 1, 'should have exactly one result');
       assert.ok(filtered.i18n, 'filtered result should have i18n');
       assert.ok(filtered.i18n[targetUniqueName], 'i18n should contain the matched item');
       assert.strictEqual(Object.keys(filtered.i18n).length, 1, 'i18n should only contain the matched item');
+    });
+    it('edge case: should ignore i18n entry when is missing from original', async () => {
+      const items = await wrapConstr({ category: ['Pets'], i18n: ['es'] });
+      const targetUniqueName = items[0]?.uniqueName;
+      items.i18n = {}; // simulate missing i18n entries
+      const filtered = items.filter((i) => i.uniqueName === targetUniqueName);
+      assert.strictEqual(filtered.length, 1, 'should have exactly one result');
+      assert.ok(filtered.i18n, 'filtered result should have i18n');
+      assert.strictEqual(Object.keys(filtered.i18n).length, 0, 'i18n should be empty when original is empty');
     });
     describe('helminth', async () => {
       it('should only have drops', async () => {

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -337,15 +337,11 @@ const test = (base) => {
       const realLength = items.length;
       assert(realLength === items.map((x) => x).length);
     });
-    it('should preserve i18n and versions after filter and map', async () => {
+    it('should preserve i18n and versions after filter', async () => {
       const items = await wrapConstr({ category: ['Pets'], i18n: ['es'] });
       const filtered = items.filter(() => true);
       assert.deepStrictEqual(filtered.i18n, items.i18n, 'filter should preserve i18n');
       assert.deepStrictEqual(filtered.versions, items.versions, 'filter should preserve versions');
-
-      const mapped = items.map((x) => x);
-      assert.deepStrictEqual(mapped.i18n, items.i18n, 'map should preserve i18n');
-      assert.deepStrictEqual(mapped.versions, items.versions, 'map should preserve versions');
     });
     it('should filter i18n entries to only matched items', async () => {
       const items = await wrapConstr({ category: ['Pets'], i18n: ['es'] });

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -337,6 +337,25 @@ const test = (base) => {
       const realLength = items.length;
       assert(realLength === items.map((x) => x).length);
     });
+    it('should preserve i18n and versions after filter and map', async () => {
+      const items = await wrapConstr({ category: ['Pets'], i18n: ['es'] });
+      const filtered = items.filter(() => true);
+      assert.deepStrictEqual(filtered.i18n, items.i18n, 'filter should preserve i18n');
+      assert.deepStrictEqual(filtered.versions, items.versions, 'filter should preserve versions');
+
+      const mapped = items.map((x) => x);
+      assert.deepStrictEqual(mapped.i18n, items.i18n, 'map should preserve i18n');
+      assert.deepStrictEqual(mapped.versions, items.versions, 'map should preserve versions');
+    });
+    it('should filter i18n entries to only matched items', async () => {
+      const targetUniqueName = '/Lotus/Types/Friendly/Pets/ZanukaPets/ZanukaPetParts/ZanukaPetPartHeadB';
+      const items = await wrapConstr({ category: ['Pets'], i18n: ['es'] });
+      const filtered = items.filter((i) => i.uniqueName === targetUniqueName);
+      assert.strictEqual(filtered.length, 1, 'should have exactly one result');
+      assert.ok(filtered.i18n, 'filtered result should have i18n');
+      assert.ok(filtered.i18n[targetUniqueName], 'i18n should contain the matched item');
+      assert.strictEqual(Object.keys(filtered.i18n).length, 1, 'i18n should only contain the matched item');
+    });
     describe('helminth', async () => {
       it('should only have drops', async () => {
         const items = await wrapConstr({ category: ['Warframes'] });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Using .filter function now keeps the i18n object

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this PR include updated data files in a separate commit that can be reverted for a clean code-only PR? **No**
- Have I run the linter? **Yes**
- Is a bug fix, feature request, or enhancement? **Bug Fix/Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Filter operations now preserve and propagate localization (i18n) and version metadata from the source collection, and trim the localization to only entries remaining after filtering.

* **Tests**
  * Added tests verifying that filtering preserves localization and version metadata, that filtered localization contains only retained entries, and that an empty source localization yields an empty result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->