### PR TITLE
fix: ensure i18n objects are shallow copied

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,8 @@ module.exports = class Items extends Array {
         if (this.options.i18n) {
           // only insert i18n for the objects we're inserting, so we don't bloat memory
           if (Array.isArray(this.options.i18n)) {
-            const raw = i18n[item.uniqueName];
+            const itemI18n = i18n[item.uniqueName];
+            const raw = itemI18n ? { ...itemI18n } : undefined;
             // only process if passed language is a supported i18n value
             if (raw) {
               Object.keys(raw).forEach((locale) => {

--- a/index.mjs
+++ b/index.mjs
@@ -104,7 +104,8 @@ export default class Items extends Array {
         if (this.options.i18n) {
           // only insert i18n for the objects we're inserting so we don't bloat memory
           if (Array.isArray(this.options.i18n)) {
-            const raw = i18n[item.uniqueName];
+            const itemI18n = i18n[item.uniqueName];
+            const raw = itemI18n ? { ...itemI18n } : undefined;
             // only process if passed language is a supported i18n value
             if (raw) {
               Object.keys(raw).forEach((locale) => {

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -127,6 +127,18 @@ const test = (base) => {
         assert(!!items[0].i18n.es);
         assert(!items.i18n);
       });
+      it('should have i18n on object for different locales in same runtime', async () => {
+        const getItem = async (locale) => {
+          const items = await wrapConstr({ category: ['Pets'], i18n: [locale], i18nOnObject: true });
+          const firstItem = items[0];
+          return firstItem?.i18n;
+        };
+
+        const esI18n = await getItem('es');
+        assert.ok(esI18n.es, 'should have i18n on object for es');
+        const jaI18n = await getItem('ja');
+        assert.ok(jaI18n.ja, 'should have i18n on object for ja');
+      });
     });
     describe('drops', () => {
       beforeEach(gc);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
When changing locales within the same runtime environment, the returned array did not include the i18n entries for the new locale.
This pull request replaces the reference to the global i18n object with a shallow copy to resolve this issue.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internationalization data handling to properly isolate locale entries and prevent shared reference mutations.

* **Tests**
  * Added test coverage for multi-locale internationalization scenarios, validating correct behavior across sequential locale operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->