### PR TITLE
feat(items): extract ExilusPolarity from wiki for weapons and warframes

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -997,6 +997,7 @@ class Parser {
     item.aura = wikiaItem.auraPolarity;
     item.conclave = wikiaItem.conclave;
     item.color = wikiaItem.color;
+    item.exilusPolarity = wikiaItem.exilusPolarity;
     item.introduced = wikiaItem.introduced as never;
     item.marketCost = wikiaItem.marketCost;
     item.bpCost = wikiaItem.bpCost;
@@ -1018,6 +1019,7 @@ class Parser {
     item.masteryReq = item.masteryReq ?? wikiaItem.mr;
     item.polarities = wikiaItem.polarities;
     item.tags = wikiaItem.tags?.filter((t) => Boolean(t.trim()));
+    item.exilusPolarity = wikiaItem.exilusPolarity;
     item.stancePolarity = wikiaItem.stancePolarity;
     item.wikiaThumbnail = wikiaItem.thumbnail;
     item.wikiaUrl = wikiaItem.url;

--- a/build/types/shared.ts
+++ b/build/types/shared.ts
@@ -109,6 +109,7 @@ export interface WikiaWeapon {
   attacks?: unknown[];
   ammo?: number;
   polarities?: string[];
+  exilusPolarity?: string;
   stancePolarity?: string;
   tags?: string[];
   thumbnail?: string;
@@ -124,6 +125,7 @@ export interface WikiaWarframe {
   uniqueName?: string;
   url: string;
   auraPolarity?: string;
+  exilusPolarity?: string;
   conclave?: number;
   mr?: number;
   polarities?: string[];
@@ -338,6 +340,7 @@ export interface ItemComplete extends Item {
   attacks?: unknown[];
   ammo?: number;
   tags?: string[];
+  exilusPolarity?: string;
   stancePolarity?: string;
   disposition?: number;
   omegaAttenuation?: number;

--- a/build/wikia/transformers/transformPolarity.ts
+++ b/build/wikia/transformers/transformPolarity.ts
@@ -22,6 +22,7 @@ const transform = (field: string | string[] | undefined): string | string[] | un
 
 interface PolaritySource {
   AuraPolarity?: string;
+  ExilusPolarity?: string;
   StancePolarity?: string;
   Polarity?: string;
   Polarities?: string[];
@@ -29,6 +30,7 @@ interface PolaritySource {
 
 interface PolarityTarget {
   auraPolarity?: string;
+  exilusPolarity?: string;
   stancePolarity?: string;
   polarity?: string;
   polarities?: string[];
@@ -44,6 +46,7 @@ interface PolarityTarget {
 export default <T extends PolarityTarget>(source: PolaritySource, target: T): T => {
   const output = { ...target };
   output.auraPolarity = transform(source.AuraPolarity) as string | undefined;
+  output.exilusPolarity = transform(source.ExilusPolarity) as string | undefined;
   output.stancePolarity = transform(source.StancePolarity) as string | undefined;
   output.polarity = transform(source.Polarity) as string | undefined;
   output.polarities = source.Polarities?.length ? (transform(source.Polarities) as string[]) : undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,7 @@ declare module '@wfcd/items' {
   interface Equippable {
     hexColours?: Colour[];
     polarities?: Polarity[];
+    exilusPolarity?: Polarity;
     slot?: number;
   }
   interface Buildable {


### PR DESCRIPTION
`Module:Weapons/data` and `Module:Warframes/data` both include `ExilusPolarity` for ~95% of weapons and warframes, but `transformPolarity` never extracted it. This adds the missing field.

Without this, there's no way to read a weapon's innate exilus polarity from the data directly. Forma-cost calculators, for instance, currently have to assume every exilus slot is unpolarized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Exilus polarity support. The system now parses and maintains Exilus polarity data for warframes and weapons in addition to existing polarity types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->