### PR TITLE
fix: `addIsPrime` not flagging some prime items as primes

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -837,7 +837,19 @@ class Parser {
    * @param item to check for prime status
    */
   addIsPrime(item: ItemComplete): void {
-    const allowedPrimes = ['Warframes', 'Primary', 'Secondary', 'Melee', 'Sentinels', 'Pets', 'Archwing', 'Mods'];
+    const allowedPrimes = [
+      'Warframes',
+      'Primary',
+      'Secondary',
+      'Melee',
+      'Sentinels',
+      'Pets',
+      'Archwing',
+      'Arch-Gun',
+      'Arch-Melee',
+      'Mods',
+    ];
+
     if (!allowedPrimes.includes(item.category)) return;
 
     const unameSegments = item.uniqueName.split('/');

--- a/build/parser.ts
+++ b/build/parser.ts
@@ -81,6 +81,19 @@ const primeExcludeRegex = /(^Noggle .*|Extractor .*|^[A-Z] Prime$|^Excalibur .*|
 const prefixed = (name: string): RegExp =>
   new RegExp(`(((?:${prefixes.join('|')})\\s?${name}.*)|(?:${name}\\s?(?:${suffixes.join('|')})\\s?.*))+`, 'i');
 
+const allowedPrimes = [
+  'Warframes',
+  'Primary',
+  'Secondary',
+  'Melee',
+  'Sentinels',
+  'Pets',
+  'Archwing',
+  'Arch-Gun',
+  'Arch-Melee',
+  'Mods',
+];
+
 /**
  * Drop comparator
  * Compares drop locations for items lexicographically by chance + location + rotation + rarity
@@ -837,19 +850,6 @@ class Parser {
    * @param item to check for prime status
    */
   addIsPrime(item: ItemComplete): void {
-    const allowedPrimes = [
-      'Warframes',
-      'Primary',
-      'Secondary',
-      'Melee',
-      'Sentinels',
-      'Pets',
-      'Archwing',
-      'Arch-Gun',
-      'Arch-Melee',
-      'Mods',
-    ];
-
     if (!allowedPrimes.includes(item.category)) return;
 
     const unameSegments = item.uniqueName.split('/');

--- a/build/parser.ts
+++ b/build/parser.ts
@@ -837,37 +837,22 @@ class Parser {
    * @param item to check for prime status
    */
   addIsPrime(item: ItemComplete): void {
+    const allowedPrimes = ['Warframes', 'Primary', 'Secondary', 'Melee', 'Sentinels', 'Pets', 'Archwing', 'Mods'];
+    if (!allowedPrimes.includes(item.category)) return;
+
     const unameSegments = item.uniqueName.split('/');
     const lastUnameSegment = unameSegments[unameSegments.length - 1] ?? '';
-    switch (item.category) {
-      case 'Mods':
-        {
-          const isLegendary = item.rarity === 'Legendary';
-          const isExpert =
-            lastUnameSegment.includes('Expert') || (unameSegments[unameSegments.length - 2] ?? '') === 'Expert';
-          item.isPrime = isLegendary && (isExpert || lastUnameSegment.includes('Primed'));
-        }
-        break;
-      case 'Warframes':
-        item.isPrime = item.uniqueName.endsWith('Prime');
-        break;
-      case 'Primary':
-      case 'Secondary':
-      case 'Melee':
-      case 'Arch-Gun':
-      case 'Arch-Melee':
-        item.isPrime = item.tags?.includes('Prime') ?? lastUnameSegment.includes('Prime');
-        break;
-      case 'Sentinels':
-        item.isPrime = lastUnameSegment.startsWith('Prime') || item.name.endsWith('Prime');
-        break;
-      // there is only one archwing prime so far so we cant extrapolate much
-      case 'Archwing':
-        item.isPrime = item.uniqueName.includes('Prime');
-        break;
-      default:
-        break;
+
+    item.isPrime = lastUnameSegment.includes('Prime');
+
+    if (item.category === 'Mods') {
+      const isLegendary = item.rarity === 'Legendary';
+      const isExpert =
+        lastUnameSegment.includes('Expert') || (unameSegments[unameSegments.length - 2] ?? '') === 'Expert';
+      item.isPrime = isLegendary && (isExpert || lastUnameSegment.includes('Primed'));
     }
+
+    return;
   }
 
   /**


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #899 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal item detection to provide more consistent identification of "Prime" items across categories.
  * Mod items now have more accurate rarity-based classification, reducing incorrect Prime/Primed labeling.
  * Overall logic streamlined to reduce inconsistent behavior when displaying item status and rarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->