### PR TITLE
fix: exempt orion from components check

### DIFF
--- a/test/index.regression.spec.mjs
+++ b/test/index.regression.spec.mjs
@@ -13,7 +13,7 @@ const data = {
   mods: undefined,
 };
 
-const namedExclusions = ['Excalibur Prime', 'Helminth'];
+const namedExclusions = ['Excalibur Prime', 'Helminth', 'Orion & Sirius'];
 
 data.items = await grab('items');
 data.weapons = await grab('weapons');

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -35,7 +35,7 @@ const wrapConstr = async (opts) => {
   return items;
 };
 
-const namedExclusions = ['Excalibur Prime', 'Helminth'];
+const namedExclusions = ['Excalibur Prime', 'Helminth', 'Orion & Sirius'];
 
 const setupItems = async () => {
   Items = await importFresh(itemPath);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
fix orion & sirius conflict failing to save new data

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated component validation and regression test exclusions to skip additional warframe names (“Orion & Sirius”), improving alignment with current live/API data and preventing false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->