### PR TITLE
fix: arcanes, release dates, categories

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import minify from 'imagemin';
+import minify, { type Plugin } from 'imagemin';
 import minifyPng from 'imagemin-pngquant';
 import minifyJpeg from 'imagemin-jpegtran';
 import fetch from 'node-fetch';
@@ -264,7 +264,7 @@ class Build {
             minifyPng({
               quality: [0.2, 0.4],
             }),
-          ],
+          ] as Plugin[],
         });
 
         this.updateCache(item, cached, hash, isComponent);
@@ -374,7 +374,7 @@ class Build {
     const processedItems: Item[] = [];
     for (const imageName of Object.keys(itemsByImageName)) {
       // Items are grouped by imageName, there are non in this loop that will be undefined
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+       
       const group = itemsByImageName[imageName]!;
       if (group.length === 1) {
         processedItems.push(...group);
@@ -407,7 +407,7 @@ class Build {
         return (priorityMap[a.category] ?? Infinity) - (priorityMap[b.category] ?? Infinity);
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+       
       const mainItem = group[0]!;
       processedItems.push(mainItem);
 
@@ -432,12 +432,12 @@ class Build {
     for (const item of [...processedItems, ...noImage]) {
       if (item.productCategory && allowedCustomCategories.includes(item.productCategory)) {
         // Since we're following the same logic as applying custom categories all keys should have an empty array and if they don't we should consider it an error
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+         
         data[item.productCategory]!.push(item);
         continue;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+       
       data[item.category]!.push(item);
     }
   }

--- a/build/parser.ts
+++ b/build/parser.ts
@@ -79,6 +79,8 @@ const warnings: Warnings = {
   missingType: [],
   failedImage: [],
   missingWikiThumb: [],
+  missingReleaseDates: [],
+  ambiguousWikiMatch: [],
 };
 
 const filterBps = (blueprint: Partial<ItemComplete>): boolean => !bpConflicts.includes(blueprint.uniqueName ?? '');
@@ -230,6 +232,13 @@ class Parser {
     this.addRelics(result, data.relics, data.drops);
     this.applyMasterable(result);
     this.applyOverrides(result);
+    if (!result.releaseDate) {
+      if (result.masterable) {
+        warnings.missingReleaseDates.push(result.name);
+      } else if (result.category === 'Arcanes' && result.wikiAvailable) {
+        warnings.missingReleaseDates.push(result.name);
+      }
+    }
     return result;
   }
 
@@ -517,7 +526,7 @@ class Parser {
     }
 
     if (item.productCategory && productCategoryTypeMap[item.productCategory]) {
-      item.type = productCategoryTypeMap[item.productCategory];
+      item.type = productCategoryTypeMap[item.productCategory]!;
     }
   }
 
@@ -887,7 +896,10 @@ class Parser {
    * @param wikiaData from wikia to apply
    */
   addAdditionalWikiaData(item: ItemComplete, category: string, wikiaData: WikiaData): void {
-    if (!['weapons', 'warframes', 'mods', 'upgrades', 'sentinels'].includes(category.toLowerCase())) return;
+    if (
+      !['weapons', 'warframes', 'mods', 'upgrades', 'sentinels', 'relicarcane'].includes(category.toLowerCase())
+    )
+      return;
 
     const slots: string[][] = [
       ['Secondary'], // 0
@@ -909,33 +921,27 @@ class Parser {
 
     let wikiCategory = category.toLowerCase();
     if (category === 'Upgrades') wikiCategory = 'mods';
+    if (category === 'RelicArcane') wikiCategory = 'arcanes';
     if (item.category === 'Archwing') wikiCategory = 'archwings';
     if (category === 'Sentinels') wikiCategory = 'companions';
 
-    const wikiaItem = (wikiaData[wikiCategory as keyof WikiaData] as WikiaWeapon[]).find((i) => {
-      const uMatch = i.uniqueName === item.uniqueName;
-      let nMatch = true;
-      if (category.toLowerCase() === 'weapons' && typeof item.slot !== 'undefined') {
-        nMatch = slots[item.slot]?.includes(i.slot?.toString() ?? '') ?? false;
-      }
-      return uMatch && nMatch;
-    });
+    const wikiaItem = this.findWikiaItem(item, category, wikiCategory, wikiaData, slots);
     if (!wikiaItem) return;
     item.wikiAvailable = true;
 
     switch (category.toLowerCase()) {
       case 'sentinels':
       case 'warframes':
-        this.addWarframeWikiaData(item, wikiaItem);
+        this.addWarframeWikiaData(item, wikiaItem as WikiaWarframe);
         break;
       case 'weapons':
-        this.addWeaponWikiaData(item, wikiaItem);
+        this.addWeaponWikiaData(item, wikiaItem as WikiaWeapon);
         break;
       case 'upgrades':
-        this.addModWikiaData(item, wikiaItem);
+        this.addModWikiaData(item, wikiaItem as WikiaMod);
         break;
-      case 'arcanes':
-        this.addArcaneWikiaData(item, wikiaItem);
+      case 'relicarcane':
+        this.addArcaneWikiaData(item, wikiaItem as WikiaArcane);
         break;
       default:
         break;
@@ -945,6 +951,42 @@ class Parser {
       (v) => v.aliases.includes(wikiaItem.introduced ?? '') || v.name === wikiaItem.introduced
     );
     if (item.introduced) item.releaseDate = item.introduced.date;
+  }
+
+  /**
+   * Find a wiki entry by uniqueName, falling back to an exact name match.
+   * @param item item to match against wiki data
+   * @param category API category being parsed
+   * @param wikiCategory wiki data bucket key
+   * @param wikiaData scraped wiki data
+   * @param slots weapon slot compatibility map
+   * @returns matched wiki entry, if unambiguous
+   */
+  findWikiaItem(
+    item: ItemComplete,
+    category: string,
+    wikiCategory: string,
+    wikiaData: WikiaData,
+    slots: string[][]
+  ): { uniqueName?: string; name: string; slot?: unknown; introduced?: string } | undefined {
+    const wikiItems = (wikiaData[wikiCategory as keyof WikiaData] as
+      | { uniqueName?: string; name: string; slot?: unknown; introduced?: string }[]
+      | undefined) ?? [];
+
+    const uniqueMatch = wikiItems.find((i) => {
+      const uMatch = i.uniqueName === item.uniqueName;
+      let nMatch = true;
+      if (category.toLowerCase() === 'weapons' && typeof item.slot !== 'undefined') {
+        nMatch = slots[item.slot]?.includes(String(i.slot ?? '')) ?? false;
+      }
+      return uMatch && nMatch;
+    });
+    if (uniqueMatch) return uniqueMatch;
+
+    const nameMatches = wikiItems.filter((i) => i.name === item.name);
+    if (nameMatches.length === 1) return nameMatches[0];
+    if (nameMatches.length > 1) warnings.ambiguousWikiMatch.push(item.name);
+    return undefined;
   }
 
   addWarframeWikiaData(item: ItemComplete, wikiaItem: WikiaWarframe): void {
@@ -1018,7 +1060,7 @@ class Parser {
     item.wikiaThumbnail = wikiaItem.thumbnail;
     item.wikiaUrl = wikiaItem.url;
     item.transmutable = wikiaItem.transmutable;
-    item.type = wikiaItem.type ?? item.type;
+    item.rarity = wikiaItem.rarity ?? item.rarity;
     if (!wikiaItem.thumbnail) warnings.missingWikiThumb.push(item.name);
   }
 
@@ -1077,8 +1119,8 @@ class Parser {
    * @param drops drop rate data for refinement-specific chances
    */
   addRelics(item: ItemComplete, relics: TitaniaRelic[], drops: RawDrop[]): void {
-    const hasRelicDrop = (item.components)?.some((c): boolean =>
-      c.drops?.some((d) => d.location.includes('Relic'))
+    const hasRelicDrop = item.components?.some((c) =>
+      c.drops?.some((d) => d.location.includes('Relic')) ?? false
     );
     if (item.type !== 'Relic' && !hasRelicDrop) return;
 

--- a/build/parser.ts
+++ b/build/parser.ts
@@ -225,7 +225,7 @@ class Parser {
     this.addDucats(result, data.wikia.ducats);
     this.addDropRate(result, data.drops);
     this.addPatchlogs(result, data.patchlogs);
-    this.addAdditionalWikiaData(result, category, data.wikia);
+    this.addAdditionalWikiaData(result, data.wikia);
     this.addIsPrime(result);
     this.addVaultData(result, category, data.wikia);
     this.addResistanceData(result, category);
@@ -890,16 +890,43 @@ class Parser {
   }
 
   /**
+   * Map finalized output categories to wiki data buckets and merge handlers.
+   * @param itemCategory category assigned by addCategory
+   * @returns wiki bucket and handler key, if wiki merge applies
+   */
+  resolveWikiaConfig(itemCategory?: string): { wikiCategory: string; handler: 'warframe' | 'weapon' | 'mod' | 'arcane' } | undefined {
+    switch (itemCategory) {
+      case 'Arcanes':
+        return { wikiCategory: 'arcanes', handler: 'arcane' };
+      case 'Warframes':
+        return { wikiCategory: 'warframes', handler: 'warframe' };
+      case 'Archwing':
+        return { wikiCategory: 'archwings', handler: 'warframe' };
+      case 'Primary':
+      case 'Secondary':
+      case 'Melee':
+      case 'Arch-Gun':
+      case 'Arch-Melee':
+        return { wikiCategory: 'weapons', handler: 'weapon' };
+      case 'Mods':
+        return { wikiCategory: 'mods', handler: 'mod' };
+      case 'Sentinels':
+        return { wikiCategory: 'companions', handler: 'warframe' };
+      default:
+        return undefined;
+    }
+  }
+
+  /**
    * Adds data scraped from the wiki to a particular item
    * @param item to have wikia data added to
-   * @param category of the data
    * @param wikiaData from wikia to apply
    */
-  addAdditionalWikiaData(item: ItemComplete, category: string, wikiaData: WikiaData): void {
-    if (
-      !['weapons', 'warframes', 'mods', 'upgrades', 'sentinels', 'relicarcane'].includes(category.toLowerCase())
-    )
-      return;
+  addAdditionalWikiaData(item: ItemComplete, wikiaData: WikiaData): void {
+    const config = this.resolveWikiaConfig(item.category);
+    if (!config) return;
+
+    const { wikiCategory, handler } = config;
 
     const slots: string[][] = [
       ['Secondary'], // 0
@@ -919,28 +946,21 @@ class Parser {
       ['Railjack Turret'], // 14
     ];
 
-    let wikiCategory = category.toLowerCase();
-    if (category === 'Upgrades') wikiCategory = 'mods';
-    if (category === 'RelicArcane') wikiCategory = 'arcanes';
-    if (item.category === 'Archwing') wikiCategory = 'archwings';
-    if (category === 'Sentinels') wikiCategory = 'companions';
-
-    const wikiaItem = this.findWikiaItem(item, category, wikiCategory, wikiaData, slots);
+    const wikiaItem = this.findWikiaItem(item, wikiCategory, wikiaData, slots);
     if (!wikiaItem) return;
     item.wikiAvailable = true;
 
-    switch (category.toLowerCase()) {
-      case 'sentinels':
-      case 'warframes':
+    switch (handler) {
+      case 'warframe':
         this.addWarframeWikiaData(item, wikiaItem as WikiaWarframe);
         break;
-      case 'weapons':
+      case 'weapon':
         this.addWeaponWikiaData(item, wikiaItem as WikiaWeapon);
         break;
-      case 'upgrades':
+      case 'mod':
         this.addModWikiaData(item, wikiaItem as WikiaMod);
         break;
-      case 'relicarcane':
+      case 'arcane':
         this.addArcaneWikiaData(item, wikiaItem as WikiaArcane);
         break;
       default:
@@ -956,7 +976,6 @@ class Parser {
   /**
    * Find a wiki entry by uniqueName, falling back to an exact name match.
    * @param item item to match against wiki data
-   * @param category API category being parsed
    * @param wikiCategory wiki data bucket key
    * @param wikiaData scraped wiki data
    * @param slots weapon slot compatibility map
@@ -964,7 +983,6 @@ class Parser {
    */
   findWikiaItem(
     item: ItemComplete,
-    category: string,
     wikiCategory: string,
     wikiaData: WikiaData,
     slots: string[][]
@@ -976,7 +994,7 @@ class Parser {
     const uniqueMatch = wikiItems.find((i) => {
       const uMatch = i.uniqueName === item.uniqueName;
       let nMatch = true;
-      if (category.toLowerCase() === 'weapons' && typeof item.slot !== 'undefined') {
+      if (wikiCategory === 'weapons' && typeof item.slot !== 'undefined') {
         nMatch = slots[item.slot]?.includes(String(i.slot ?? '')) ?? false;
       }
       return uMatch && nMatch;

--- a/build/types/shared.ts
+++ b/build/types/shared.ts
@@ -82,6 +82,8 @@ export interface Warnings {
   missingType: string[];
   failedImage: string[];
   missingWikiThumb: string[];
+  missingReleaseDates: string[];
+  ambiguousWikiMatch: string[];
 }
 
 export type Locales = Record<string, Record<string, unknown>>;
@@ -158,6 +160,7 @@ export interface WikiaArcane {
   transmutable?: boolean;
   introduced?: string;
   type?: string;
+  rarity?: string;
   thumbnail?: string;
   [key: string]: unknown;
 }

--- a/build/wikia/transformers/transformArcanes.ts
+++ b/build/wikia/transformers/transformArcanes.ts
@@ -6,6 +6,7 @@ interface OldArcane {
   Transmutable?: boolean;
   Introduced?: string;
   Type?: string;
+  Rarity?: string;
   InternalName?: string;
   [key: string]: unknown;
 }
@@ -17,7 +18,7 @@ export default (oldArcane: OldArcane, imageUrls: Record<string, string>): WikiaA
   }
 
   try {
-    const { Image, Name, Transmutable, Introduced, Type, InternalName } = oldArcane;
+    const { Image, Name, Transmutable, Introduced, Type, Rarity, InternalName } = oldArcane;
 
     newArcane = {
       name: Name,
@@ -26,6 +27,7 @@ export default (oldArcane: OldArcane, imageUrls: Record<string, string>): WikiaA
       transmutable: Transmutable,
       introduced: Introduced,
       type: Type,
+      rarity: Rarity ? Rarity.charAt(0).toUpperCase() + Rarity.slice(1).toLowerCase() : undefined,
       thumbnail: imageUrls[Image ?? ''],
     };
   } catch (error) {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -34,6 +34,7 @@ export default defineConfig(
       ],
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
   // Disable type checking for all JS files

--- a/index.d.ts
+++ b/index.d.ts
@@ -249,14 +249,16 @@ declare module '@wfcd/items' {
     attacks?: Attack[];
     maxLevelCap?: number;
   }
-  interface Arcane extends Named, Buildable, Droppable {
+  interface Arcane extends Named, Buildable, Droppable, WikiaItem {
     category: 'Arcanes';
     excludeFromCodex?: true;
     imageName: string;
     levelStats?: LevelStat[];
     masterable: false;
     patchlogs?: PatchLog[];
+    releaseDate?: DateString;
     tradable: true;
+    transmutable?: boolean;
     type: 'Arcane' | `${ArcaneType} Arcane`;
   }
   interface StanceMod extends Omit<Mod, 'levelStats'> {

--- a/test/build.integrity.spec.mjs
+++ b/test/build.integrity.spec.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const all = require('../data/json/All.json');
+const arcanes = require('../data/json/Arcanes.json');
+const warnings = JSON.parse(readFileSync(new URL('../data/warnings.json', import.meta.url), 'utf8'));
+
+/** Arcane names that exist in Module:Arcane and should always merge after a build. */
+const knownWikiArcanes = [
+  'Arcane Acceleration',
+  'Arcane Aegis',
+  'Arcane Energize',
+  'Arcane Grace',
+  'Magus Elevate',
+  'Virtuos Fury',
+];
+
+/** Items with no standalone wiki Introduced entry or known InternalName gaps. */
+const allowedMissingReleaseDates = [
+  'Bad Baby',
+  'Bhaira Hound',
+  'Bonewidow',
+  'Dark Split-Sword',
+  'Dorma Hound',
+  'Enkaus',
+  'Feverspine',
+  'Flatbelly',
+  'Grimoire',
+  'Hec Hound',
+  'Imperator Vandal',
+  'Kuva Ghoulsaw',
+  'Lambeo Moa',
+  'Mandonel',
+  'Needlenose',
+  'Nychus Moa',
+  'Oloro Moa',
+  'Para Moa',
+  'Runway',
+  'Voidrig',
+];
+
+/** Skip when committed JSON predates wiki merge fixes (run `npm run build -- --force` locally). */
+const rebuiltWithWikiMerge = arcanes.some((arcane) => arcane.wikiAvailable);
+
+(rebuiltWithWikiMerge ? describe : describe.skip)('build output wiki integrity', () => {
+  it('known wiki arcanes should have merge data applied', () => {
+    knownWikiArcanes.forEach((name) => {
+      const arcane = arcanes.find((entry) => entry.name === name);
+      assert(arcane, `${name} not found in Arcanes.json`);
+      assert(arcane.wikiAvailable, `${name} missing wikiAvailable`);
+      assert(arcane.releaseDate, `${name} missing releaseDate`);
+      assert(arcane.rarity, `${name} missing rarity`);
+    });
+  });
+
+  it('arcanes with wikiAvailable should have releaseDate and rarity', () => {
+    arcanes
+      .filter((arcane) => arcane.wikiAvailable)
+      .forEach((arcane) => {
+        assert(arcane.releaseDate, `${arcane.name} missing releaseDate`);
+        assert(arcane.rarity, `${arcane.name} missing rarity`);
+      });
+  });
+
+  it('masterable primes should have releaseDate', () => {
+    const missing = all
+      .filter((item) => item.masterable && item.name.endsWith(' Prime') && !item.releaseDate)
+      .map((item) => item.name);
+
+    assert.deepStrictEqual(missing, []);
+  });
+
+  it('missingReleaseDates warnings should only contain known gaps', () => {
+    const unexpected = (warnings.missingReleaseDates ?? []).filter(
+      (name) => !allowedMissingReleaseDates.includes(name)
+    );
+    assert.deepStrictEqual(
+      unexpected,
+      [],
+      `Unexpected missingReleaseDates entries: ${unexpected.join(', ')}`
+    );
+  });
+
+  it('ambiguousWikiMatch warnings should be empty', () => {
+    assert.deepStrictEqual(warnings.ambiguousWikiMatch ?? [], []);
+  });
+});

--- a/test/fixtures/wikia.fixture.mjs
+++ b/test/fixtures/wikia.fixture.mjs
@@ -1,0 +1,85 @@
+/** @typedef {import('../../build/types/shared').RawItemData} RawItemData */
+/** @typedef {import('../../build/types/shared').WikiaData} WikiaData */
+
+/** @type {import('../../build/types/shared').WikiaVersion[]} */
+export const versions = [
+  { name: 'Update 38.6', aliases: ['Update 38.6'], date: '2025-05-21' },
+  { name: 'Update 16.1', aliases: ['Update 16.1'], date: '2015-03-25' },
+];
+
+/** @returns {WikiaData} */
+export const baseWikia = () => ({
+  weapons: [
+    {
+      name: 'Quassus Prime',
+      uniqueName: '/Lotus/Weapons/Tenno/Melee/Warfan/TnBrokenFrameWarfan/TnBrokenFramePrimeWarfanWeapon',
+      url: 'https://wiki.warframe.com/w/Quassus_Prime',
+      introduced: 'Update 38.6',
+      slot: 'Melee',
+    },
+    {
+      name: 'Braton',
+      uniqueName: '/Lotus/Weapons/Tenno/LongGuns/Braton/Braton',
+      url: 'https://wiki.warframe.com/w/Braton',
+      introduced: 'Update 38.6',
+      slot: 'Primary',
+    },
+    {
+      name: 'Braton',
+      uniqueName: '/Lotus/Weapons/Tenno/Pistols/Braton/BratonPistol',
+      url: 'https://wiki.warframe.com/w/Braton',
+      introduced: 'Update 38.6',
+      slot: 'Secondary',
+    },
+  ],
+  warframes: [],
+  mods: [],
+  versions,
+  ducats: [],
+  arcanes: [
+    {
+      name: 'Arcane Acceleration',
+      uniqueName: '/Lotus/Upgrades/Cosmetic/Arcane/LotusArcaneAcceleration',
+      url: 'https://wiki.warframe.com/w/Arcane_Acceleration',
+      introduced: 'Update 38.6',
+      type: 'Warframe',
+      rarity: 'Uncommon',
+    },
+    {
+      name: 'Arcane Aegis',
+      uniqueName: '/Lotus/Upgrades/Cosmetic/Arcane/LotusArcaneAegis',
+      url: 'https://wiki.warframe.com/w/Arcane_Aegis',
+      introduced: 'Update 38.6',
+      type: 'Warframe',
+      rarity: 'Rare',
+    },
+  ],
+  archwings: [],
+  companions: [
+    {
+      name: 'Wyrm Prime',
+      uniqueName: '/Lotus/Types/Sentinels/SentinelPowersuits/WyrmPrimePowerSuit',
+      url: 'https://wiki.warframe.com/w/Wyrm_Prime',
+      introduced: 'Update 16.1',
+    },
+  ],
+  vaultData: [],
+});
+
+/**
+ * @param {Partial<RawItemData>} overrides
+ * @returns {RawItemData}
+ */
+export const buildRaw = (overrides = {}) => ({
+  api: [],
+  manifest: [],
+  drops: [],
+  patchlogs: { changed: false, posts: [], patchlogs: { getItemChanges: () => [] } },
+  wikia: baseWikia(),
+  relics: [],
+  i18n: { en: [] },
+  ...overrides,
+});
+
+/** @param {import('../../build/types/shared').CategoryData[]} categories */
+export const withApi = (categories) => buildRaw({ api: categories });

--- a/test/parser.wikia.spec.mjs
+++ b/test/parser.wikia.spec.mjs
@@ -32,6 +32,29 @@ describe('parser wiki merge', () => {
     assert.strictEqual(arcane?.rarity, 'Uncommon');
   });
 
+  it('does not merge relic entries from RelicArcane into the arcanes wiki bucket', () => {
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'RelicArcane',
+            data: [
+              {
+                name: 'Lith A1 Relic',
+                uniqueName: '/Lotus/Types/Keys/Projections/LithA1Relic',
+                type: 'Relic',
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const relic = findItem(parsed, 'Lith A1 Relic');
+    assert.strictEqual(relic?.category, 'Relics');
+    assert.strictEqual(relic?.wikiAvailable, undefined);
+  });
+
   it('falls back to an exact name match when uniqueName mismatches', () => {
     const parsed = parser.parse(
       buildRaw({

--- a/test/parser.wikia.spec.mjs
+++ b/test/parser.wikia.spec.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert';
+
+import parser from '../build/parser';
+import transformArcanes from '../build/wikia/transformers/transformArcanes';
+import { baseWikia, buildRaw } from './fixtures/wikia.fixture.mjs';
+
+const findItem = (parsed, name) => parsed.data.flatMap((c) => c.data).find((i) => i.name === name);
+
+describe('parser wiki merge', () => {
+  it('merges RelicArcane items from the arcanes wiki bucket', () => {
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'RelicArcane',
+            data: [
+              {
+                name: 'Arcane Acceleration',
+                uniqueName: '/Lotus/Upgrades/Cosmetic/Arcane/LotusArcaneAcceleration',
+                type: 'Arcane',
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const arcane = findItem(parsed, 'Arcane Acceleration');
+    assert.strictEqual(arcane?.category, 'Arcanes');
+    assert.strictEqual(arcane?.wikiAvailable, true);
+    assert.strictEqual(arcane?.releaseDate, '2025-05-21');
+    assert.strictEqual(arcane?.rarity, 'Uncommon');
+  });
+
+  it('falls back to an exact name match when uniqueName mismatches', () => {
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'Weapons',
+            data: [
+              {
+                name: 'Quassus Prime',
+                uniqueName: '/Lotus/Weapons/Tenno/Melee/Warfan/PrimeQuassus/PrimeQuassusWeapon',
+                slot: 5,
+                masteryReq: 14,
+              },
+            ],
+          },
+          {
+            category: 'Sentinels',
+            data: [
+              {
+                name: 'Wyrm Prime',
+                uniqueName: '/Lotus/Types/Sentinels/SentinelPowersuits/PrimeWyrmPowerSuit',
+                type: 'Sentinel',
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    assert.strictEqual(findItem(parsed, 'Quassus Prime')?.releaseDate, '2025-05-21');
+    assert.strictEqual(findItem(parsed, 'Wyrm Prime')?.releaseDate, '2015-03-25');
+  });
+
+  it('does not auto-match ambiguous wiki names', () => {
+    const wikia = baseWikia();
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'Weapons',
+            data: [
+              {
+                name: 'Braton',
+                uniqueName: '/Lotus/Weapons/Tenno/LongGuns/Braton/BratonMk1',
+                slot: 1,
+              },
+            ],
+          },
+        ],
+        wikia,
+      })
+    );
+
+    const braton = findItem(parsed, 'Braton');
+    assert.strictEqual(braton?.wikiAvailable, undefined);
+    assert(parsed.warnings.ambiguousWikiMatch.includes('Braton'));
+  });
+
+  it('preserves DE rarity when wiki rarity is absent', () => {
+    const wikia = baseWikia();
+    wikia.arcanes = [
+      {
+        name: 'Arcane Nullifier',
+        uniqueName: '/Lotus/Upgrades/Cosmetic/Arcane/LotusArcaneNullifier',
+        url: 'https://wiki.warframe.com/w/Arcane_Nullifier',
+        introduced: 'Update 38.6',
+        type: 'Warframe',
+      },
+    ];
+
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'RelicArcane',
+            data: [
+              {
+                name: 'Arcane Nullifier',
+                uniqueName: '/Lotus/Upgrades/Cosmetic/Arcane/LotusArcaneNullifier',
+                type: 'Arcane',
+                rarity: 'Rare',
+              },
+            ],
+          },
+        ],
+        wikia,
+      })
+    );
+
+    assert.strictEqual(findItem(parsed, 'Arcane Nullifier')?.rarity, 'Rare');
+  });
+
+  it('warns when a merged arcane is missing releaseDate', () => {
+    const wikia = baseWikia();
+    wikia.versions = [];
+
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'RelicArcane',
+            data: [
+              {
+                name: 'Arcane Acceleration',
+                uniqueName: '/Lotus/Upgrades/Cosmetic/Arcane/LotusArcaneAcceleration',
+                type: 'Arcane',
+              },
+            ],
+          },
+        ],
+        wikia,
+      })
+    );
+
+    assert.strictEqual(findItem(parsed, 'Arcane Acceleration')?.wikiAvailable, true);
+    assert(parsed.warnings.missingReleaseDates.includes('Arcane Acceleration'));
+  });
+
+  it('does not warn when an arcane is absent from wiki data', () => {
+    const wikia = baseWikia();
+    wikia.arcanes = [];
+
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'RelicArcane',
+            data: [
+              {
+                name: 'Arcane Defense',
+                uniqueName: '/Lotus/Upgrades/CosmeticEnhancers/Defensive/PunctureProcResist',
+                type: 'Arcane',
+              },
+            ],
+          },
+        ],
+        wikia,
+      })
+    );
+
+    assert.strictEqual(findItem(parsed, 'Arcane Defense')?.wikiAvailable, undefined);
+    assert(!parsed.warnings.missingReleaseDates.includes('Arcane Defense'));
+  });
+});
+
+describe('transformArcanes', () => {
+  it('titlecases wiki rarity values', () => {
+    const arcane = transformArcanes({ Name: 'Arcane Test', Rarity: 'legendary' }, {});
+    assert.strictEqual(arcane?.rarity, 'Legendary');
+  });
+
+  it('leaves rarity undefined when wiki omits it', () => {
+    const arcane = transformArcanes({ Name: 'Arcane Test' }, {});
+    assert.strictEqual(arcane?.rarity, undefined);
+  });
+});


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #779, closes #876, closes #875

---

### Reproduction steps
build & check?

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved data enrichment for items, including better handling of arcane details and wiki-based metadata.
  * Added support for showing additional item information such as release dates and rarity when available.

* **Bug Fixes**
  * Improved matching when combining item data from multiple sources, reducing incorrect or ambiguous matches.
  * Added clearer warnings for missing release dates so incomplete entries are easier to spot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->