### PR TITLE
feat: exalted slot

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -33,6 +33,7 @@ import type {
   Affector,
   Resistance,
   ApiCategory,
+  ExaltedSlot,
 } from './types/shared';
 
 const previousBuild = await readJson<ItemComplete[]>(new URL('../data/json/All.json', import.meta.url));
@@ -81,6 +82,7 @@ const warnings: Warnings = {
   missingWikiThumb: [],
   missingReleaseDates: [],
   ambiguousWikiMatch: [],
+  missingExaltedSlot: [],
 };
 
 const filterBps = (blueprint: Partial<ItemComplete>): boolean => !bpConflicts.includes(blueprint.uniqueName ?? '');
@@ -232,6 +234,7 @@ class Parser {
     this.addRelics(result, data.relics, data.drops);
     this.applyMasterable(result);
     this.applyOverrides(result);
+    this.addExaltedSlot(result, data.wikia);
     if (!result.releaseDate) {
       if (result.masterable) {
         warnings.missingReleaseDates.push(result.name);
@@ -891,11 +894,22 @@ class Parser {
 
   /**
    * Map finalized output categories to wiki data buckets and merge handlers.
-   * @param itemCategory category assigned by addCategory
+   * Exalted weapons stay in Misc but still merge from the weapons wiki bucket.
+   * @param item item being merged
    * @returns wiki bucket and handler key, if wiki merge applies
    */
-  resolveWikiaConfig(itemCategory?: string): { wikiCategory: string; handler: 'warframe' | 'weapon' | 'mod' | 'arcane' } | undefined {
-    switch (itemCategory) {
+  resolveWikiaConfig(
+    item: Pick<ItemComplete, 'category' | 'type' | 'uniqueName'>
+  ): { wikiCategory: string; handler: 'warframe' | 'weapon' | 'mod' | 'arcane' } | undefined {
+    // Type overrides apply later; honor them here so exalted weapons still merge wiki Slot.
+    const type = item.type === 'Exalted Weapon' || overrides[item.uniqueName]?.type === 'Exalted Weapon'
+      ? 'Exalted Weapon'
+      : item.type;
+    if (type === 'Exalted Weapon') {
+      return { wikiCategory: 'weapons', handler: 'weapon' };
+    }
+
+    switch (item.category) {
       case 'Arcanes':
         return { wikiCategory: 'arcanes', handler: 'arcane' };
       case 'Warframes':
@@ -923,7 +937,7 @@ class Parser {
    * @param wikiaData from wikia to apply
    */
   addAdditionalWikiaData(item: ItemComplete, wikiaData: WikiaData): void {
-    const config = this.resolveWikiaConfig(item.category);
+    const config = this.resolveWikiaConfig(item);
     if (!config) return;
 
     const { wikiCategory, handler } = config;
@@ -1038,6 +1052,13 @@ class Parser {
     item.wikiaThumbnail = wikiaItem.thumbnail;
     item.wikiaUrl = wikiaItem.url;
     item.introduced = wikiaItem.introduced as never;
+
+    const isExaltedWeapon =
+      item.type === 'Exalted Weapon' || overrides[item.uniqueName]?.type === 'Exalted Weapon';
+    if (isExaltedWeapon) {
+      const exaltedSlot = this.mapWikiSlotToExaltedSlot(wikiaItem.slot);
+      if (exaltedSlot) item.exaltedSlot = exaltedSlot;
+    }
 
     if (item.omegaAttenuation && item.omegaAttenuation <= 0.75) {
       item.disposition = 1;
@@ -1232,6 +1253,74 @@ class Parser {
       const regex = new RegExp(masterableCategories.regex);
       item.masterable = regex.test(item.uniqueName);
     }
+  }
+
+  /**
+   * Map wiki weapon Slot strings onto ExaltedSlot values.
+   * @param slot wiki Slot field
+   * @returns matching exalted slot, if known
+   */
+  mapWikiSlotToExaltedSlot(slot: unknown): ExaltedSlot | undefined {
+    switch (String(slot ?? '')) {
+      case 'Primary':
+        return 'Primary';
+      case 'Secondary':
+        return 'Secondary';
+      case 'Melee':
+        return 'Melee';
+      case 'Archgun':
+      case 'Archgun (Atmosphere)':
+      case 'Arch-Gun':
+        return 'Arch-Gun';
+      case 'Archmelee':
+      case 'Arch-Melee':
+        return 'Arch-Melee';
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Assign loadout slot classification for exalted weapons.
+   * Prefers wiki Slot (via prior wiki merge), then a direct weapons-bucket lookup,
+   * then melee/gun stat inference. Primary vs Secondary cannot be inferred from
+   * DE stats alone, so gun-like weapons without wiki data warn instead.
+   * @param item item to annotate
+   * @param wikiaData scraped wiki data
+   */
+  addExaltedSlot(item: ItemComplete, wikiaData: WikiaData): void {
+    if (item.type !== 'Exalted Weapon') return;
+    if (item.exaltedSlot) return;
+
+    const wikiWeapon =
+      wikiaData.weapons.find((weapon) => weapon.uniqueName === item.uniqueName) ??
+      (() => {
+        const nameMatches = wikiaData.weapons.filter((weapon) => weapon.name === item.name);
+        return nameMatches.length === 1 ? nameMatches[0] : undefined;
+      })();
+
+    const fromWiki = this.mapWikiSlotToExaltedSlot(wikiWeapon?.slot);
+    if (fromWiki) {
+      item.exaltedSlot = fromWiki;
+      return;
+    }
+
+    const isMelee = Boolean(
+      item.blockingAngle ?? item.comboDuration ?? item.stancePolarity ?? item.slamAttack
+    );
+    const isGun = Boolean(
+      item.accuracy !== undefined ||
+        item.reloadTime !== undefined ||
+        item.magazineSize !== undefined ||
+        item.trigger
+    );
+
+    if (isMelee && !isGun) {
+      item.exaltedSlot = 'Melee';
+      return;
+    }
+
+    warnings.missingExaltedSlot.push(item.name);
   }
 
   addResistanceData(item: ItemComplete, category: string): void {

--- a/build/scraper.ts
+++ b/build/scraper.ts
@@ -223,7 +223,7 @@ class Scraper {
     const bar = skipProgress ? undefined : new Progress('Fetching Image Manifest', 1);
     const endpoint = await this.fetchEndpoints(true);
     if (!endpoint) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+       
       console.error(`No Image Manifest Retrieved from API: ${endpoint!}`);
       return process.exit(1);
     }

--- a/build/types/shared.ts
+++ b/build/types/shared.ts
@@ -84,6 +84,7 @@ export interface Warnings {
   missingWikiThumb: string[];
   missingReleaseDates: string[];
   ambiguousWikiMatch: string[];
+  missingExaltedSlot: string[];
 }
 
 export type Locales = Record<string, Record<string, unknown>>;
@@ -108,7 +109,7 @@ export interface WikiaWeapon {
   mr?: number;
   type?: string;
   class?: string;
-  slot?: number;
+  slot?: string | number;
   attacks?: unknown[];
   ammo?: number;
   polarities?: string[];
@@ -303,6 +304,8 @@ export interface MasterableCategories {
   regex: string;
 }
 
+export type ExaltedSlot = 'Primary' | 'Secondary' | 'Melee' | 'Arch-Gun' | 'Arch-Melee';
+
 export interface ApiCategory {
   category?: string;
   data: Partial<Item>[];
@@ -376,6 +379,7 @@ export interface ItemComplete extends Item {
   levelStats?: unknown[];
   parent?: string;
   parents?: string[];
+  exaltedSlot?: ExaltedSlot;
 }
 
 export interface Damage {

--- a/index.d.ts
+++ b/index.d.ts
@@ -233,6 +233,7 @@ declare module '@wfcd/items' {
   interface ExaltedWeapon extends Omit<Gun, 'category'>, Omit<Melee, 'category'>, Omit<Weapon, 'category'> {
     category: 'Misc';
     type: 'Exalted Weapon';
+    exaltedSlot: ExaltedSlot;
   }
   interface Weapon extends Equippable, Buildable, Attackable, WikiaItem, BaseItem {
     category: Gun['category'] | Melee['category'];
@@ -706,6 +707,8 @@ declare module '@wfcd/items' {
     | 'Skins'
     | 'Warframes'
     | Weapon['category'];
+
+  type ExaltedSlot = 'Primary' | 'Secondary' | 'Melee' | 'Arch-Gun' | 'Arch-Melee';
 
   /**
    * Riven disposition, a multiplier & range for omegaAttenuation

--- a/test/build.integrity.spec.mjs
+++ b/test/build.integrity.spec.mjs
@@ -8,6 +8,8 @@ const all = require('../data/json/All.json');
 const arcanes = require('../data/json/Arcanes.json');
 const warnings = JSON.parse(readFileSync(new URL('../data/warnings.json', import.meta.url), 'utf8'));
 
+const exaltedSlotValues = ['Primary', 'Secondary', 'Melee', 'Arch-Gun', 'Arch-Melee'];
+
 /** Arcane names that exist in Module:Arcane and should always merge after a build. */
 const knownWikiArcanes = [
   'Arcane Acceleration',
@@ -86,5 +88,22 @@ const rebuiltWithWikiMerge = arcanes.some((arcane) => arcane.wikiAvailable);
 
   it('ambiguousWikiMatch warnings should be empty', () => {
     assert.deepStrictEqual(warnings.ambiguousWikiMatch ?? [], []);
+  });
+});
+
+describe('exalted weapon slot integrity', () => {
+  it('every exalted weapon should have a valid exaltedSlot', () => {
+    const exalted = all.filter((item) => item.type === 'Exalted Weapon');
+    const missing = exalted.filter((item) => !item.exaltedSlot).map((item) => item.name);
+    assert.deepStrictEqual(missing, [], `Missing exaltedSlot: ${missing.join(', ')}`);
+
+    const invalid = exalted
+      .filter((item) => !exaltedSlotValues.includes(item.exaltedSlot))
+      .map((item) => item.name);
+    assert.deepStrictEqual(invalid, [], `Invalid exaltedSlot: ${invalid.join(', ')}`);
+  });
+
+  it('missingExaltedSlot warnings should be empty', () => {
+    assert.deepStrictEqual(warnings.missingExaltedSlot ?? [], []);
   });
 });

--- a/test/parser.wikia.spec.mjs
+++ b/test/parser.wikia.spec.mjs
@@ -200,6 +200,102 @@ describe('parser wiki merge', () => {
   });
 });
 
+describe('exaltedSlot from wiki', () => {
+  it('maps wiki Slot onto exaltedSlot for exalted weapons', () => {
+    const wikia = baseWikia();
+    wikia.weapons.push(
+      {
+        name: 'Dex Pixia',
+        uniqueName: '/Lotus/Powersuits/Fairy/FlightPistols',
+        url: 'https://wiki.warframe.com/w/Dex_Pixia',
+        introduced: 'Update 38.6',
+        slot: 'Secondary',
+      },
+      {
+        name: 'Arquebex',
+        uniqueName: '/Lotus/Types/Enemies/Orokin/Entrati/EntratiTech/NechroTech/ExaltedArtilleryWeapon',
+        url: 'https://wiki.warframe.com/w/Arquebex',
+        introduced: 'Update 38.6',
+        slot: 'Archgun (Atmosphere)',
+      },
+      {
+        name: 'Ironbride',
+        uniqueName: '/Lotus/Types/Enemies/Orokin/Entrati/EntratiTech/NechroTech/AbilitySword/NechroTechSwordWeapon',
+        url: 'https://wiki.warframe.com/w/Ironbride',
+        introduced: 'Update 38.6',
+        slot: 'Archmelee',
+      }
+    );
+
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'Weapons',
+            data: [
+              {
+                name: 'Dex Pixia',
+                uniqueName: '/Lotus/Powersuits/Fairy/FlightPistols',
+                productCategory: 'SpecialItems',
+                slot: 7,
+                type: 'Exalted Weapon',
+              },
+              {
+                name: 'Arquebex',
+                uniqueName:
+                  '/Lotus/Types/Enemies/Orokin/Entrati/EntratiTech/NechroTech/ExaltedArtilleryWeapon',
+                productCategory: 'SpecialItems',
+                slot: 7,
+                type: 'Exalted Weapon',
+              },
+              {
+                name: 'Ironbride',
+                uniqueName:
+                  '/Lotus/Types/Enemies/Orokin/Entrati/EntratiTech/NechroTech/AbilitySword/NechroTechSwordWeapon',
+                productCategory: 'SpecialItems',
+                slot: 7,
+                type: 'Exalted Weapon',
+                blockingAngle: 90,
+              },
+            ],
+          },
+        ],
+        wikia,
+      })
+    );
+
+    assert.strictEqual(findItem(parsed, 'Dex Pixia')?.exaltedSlot, 'Secondary');
+    assert.strictEqual(findItem(parsed, 'Arquebex')?.exaltedSlot, 'Arch-Gun');
+    assert.strictEqual(findItem(parsed, 'Ironbride')?.exaltedSlot, 'Arch-Melee');
+    assert.deepStrictEqual(parsed.warnings.missingExaltedSlot, []);
+  });
+
+  it('falls back to Melee from combat stats when wiki Slot is absent', () => {
+    const parsed = parser.parse(
+      buildRaw({
+        api: [
+          {
+            category: 'Weapons',
+            data: [
+              {
+                name: 'Desert Wind',
+                uniqueName: '/Lotus/Powersuits/Pacifist/PacifistFist',
+                productCategory: 'SpecialItems',
+                slot: 7,
+                type: 'Exalted Weapon',
+                blockingAngle: 90,
+                comboDuration: 5,
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    assert.strictEqual(findItem(parsed, 'Desert Wind')?.exaltedSlot, 'Melee');
+  });
+});
+
 describe('transformArcanes', () => {
   it('titlecases wiki rarity values', () => {
     const arcane = transformArcanes({ Name: 'Arcane Test', Rarity: 'legendary' }, {});


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #944

---

### Reproduction steps
add exalted slot for exalted weapons

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying exalted weapon slot types, with normalized slot labels shown in build output.

* **Bug Fixes**
  * Improved handling of weapon data from wiki sources so exalted weapons are classified more reliably, even when slot details are missing or formatted inconsistently.
  * Added warnings when a slot can’t be determined, helping surface incomplete item data.

* **Tests**
  * Expanded build and parsing checks to verify exalted weapon slot values are valid and always present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->