### PR TITLE
fix: keep `codexSecret` in item

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -477,7 +477,6 @@ class Parser {
     }
 
     // Remove keys that only increase output size.
-    delete item.codexSecret;
     if (item.type !== 'enemy') delete item.longDescription;
     delete item.parentName;
     delete item.relicRewards; // We'll fetch the official drop data for this

--- a/index.d.ts
+++ b/index.d.ts
@@ -254,6 +254,7 @@ declare module '@wfcd/items' {
   interface Arcane extends Named, Buildable, Droppable, WikiaItem {
     category: 'Arcanes';
     excludeFromCodex?: true;
+    codexSecret?: boolean;
     imageName: string;
     levelStats?: LevelStat[];
     masterable: false;

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,7 @@ declare module '@wfcd/items' {
     imageName?: string;
     description?: string;
     releaseDate?: string;
+    codexSecret?: boolean;
     excludeFromCodex?: boolean;
     masterable: boolean;
   }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #965 
---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the `codexSecret` setting during item processing.
  * Exposed the optional `codexSecret` property in the public item type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->