### PR TITLE
fix: add check for Sagek Prime and Galariak Prime components

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -223,9 +223,9 @@ class Parser {
     }
 
     this.addCategory(result, category);
+    this.addDropRate(result, data.drops);
     this.addTradable(result);
     this.addDucats(result, data.wikia.ducats);
-    this.addDropRate(result, data.drops);
     this.addPatchlogs(result, data.patchlogs);
     this.addAdditionalWikiaData(result, data.wikia);
     this.addIsPrime(result);
@@ -807,11 +807,20 @@ class Parser {
             : this.findDropLocations(`${item.name} ${component.name}`, drops, true);
         component.drops = data.length ? data : [];
       }
-    } else if (item.name !== 'Blueprint') {
-      // Last word of relic is intact/rad, etc. instead of 'Relic'
-      const name = item.type === 'Relic' ? item.name.replace(/\s(\w+)$/, ' Relic') : item.name;
-      const data = this.findDropLocations(name, drops);
-      if (data.length) item.drops = data;
+    } else {
+      let name: string;
+      if (item.type === 'Relic'){
+        // Last word of relic is intact/rad, etc. instead of 'Relic'
+        name = item.name.replace(/\s(\w+)$/, ' Relic');
+      } else if (item.name === 'Blueprint' && item.parent) {
+        name = `${item.parent} ${item.name}`;
+      } else {
+        name = item.name;
+      }
+      if (name !== 'Blueprint') {
+        const data = this.findDropLocations(name, drops);
+        if (data.length) item.drops = data;
+      }
     }
   }
 

--- a/build/tradable.ts
+++ b/build/tradable.ts
@@ -1,13 +1,23 @@
+import type {
+  Drop
+} from './types/shared';
+
 interface Item {
   type: string;
   name: string;
   uniqueName: string;
   productCategory?: string;
+  drops?: Drop[];
   isAugment?: boolean;
 }
 
 const builtUntradable = [
   'Warframe',
+  'Sentinel',
+  'Archwing',
+  'Arch-Gun',
+  'Arch-Melee',
+  'Pets',
   'Throwing',
   'Shotgun',
   'Rifle',
@@ -18,24 +28,6 @@ const builtUntradable = [
   'Launcher',
   'Sniper',
 ];
-/**
- * Gate built Prime items (Warframes, weapons) from being marked tradable.
- * Built Prime items are not directly tradable -- only their individual
- * components/parts are (e.g. Loki Prime Blueprint). Components get their
- * own tradable flag set independently during parsing.
- *
- * To determine if a Prime set is tradable, check item.components for
- * parts with tradable: true.
- *
- * Item-specific tradability overrides live in config/overrides.json
- * (keyed by uniqueName) and are applied by parser.mjs applyOverrides()
- * after this check runs.
- *
- * @param item Item to check
- * @returns
- */
-const tradableConditions = (item: Item): boolean =>
-  !(builtUntradable.includes(item.type) && item.name.match(/Prime/gi));
 
 const tradableArcanes = [
   'Arcane',
@@ -54,6 +46,7 @@ const tradableArcanes = [
 
 const tradableMods = [
   'Arch-Melee Mod',
+  'Arch-Gun Mod',
   'Archwing Mod',
   'Companion Mod',
   'K-Drive Mod',
@@ -98,6 +91,40 @@ const tradableRegex =
   /(Prime|Vandal|Wraith\w|\wWraith|Rakta|Synoid|Sancti|Vaykor|Telos|Secura|Ayatan|Prisma|DamagedMech)(?!Derelict)/i;
 const untradableRegex =
   /(Glyph|Mandachord|Greater.*Lens|Sugatra|\[|SentinelWeapons|Toroid|Bait|([A-Za-z]+ (Relic)))|Umbral|Sacrificial/i;
+
+/**
+ * Gate built Prime items (Warframes, weapons) from being marked tradable.
+ * Built Prime items are not directly tradable -- only their individual
+ * components/parts are (e.g. Loki Prime Blueprint). Components get their
+ * own tradable flag set independently during parsing.
+ *
+ * To determine if a Prime set is tradable, check item.components for
+ * parts with tradable: true.
+ *
+ * Item-specific tradability overrides live in config/overrides.json
+ * (keyed by uniqueName) and are applied by parser.mjs applyOverrides()
+ * after this check runs.
+ *
+ * @param item Item to check
+ * @returns
+ */
+const tradableConditions = (item: Item): boolean => {
+  const primeItem = item.name.match(/Prime/gi);
+  if (builtUntradable.includes(item.type) && primeItem) {
+    return false
+  }
+  // calling this defensively on only prime things
+  // in case it might break something else, since we only
+  // care about prime things at the moment. Also for the few
+  // things that are prime and getting caught accidentally the 
+  // original behavior should be preserved with this tm
+  const primeFromUnique = item.uniqueName.match(/Prime/gi);
+  if ((primeFromUnique || primeItem) && !(tradableTypes.includes(item.type))) {
+    const result = !item.drops || item.drops.every((drop) => /Relic/gi.test(drop.location));
+    return result;
+  }
+  return true;
+}
 
 /**
  * Check if an item is tradable

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -203,7 +203,7 @@ const test = (base) => {
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
 
         matches[0].components.forEach(comp => {
-          assert(!comp.tradable)
+          assert.strictEqual(comp.tradable, false);
         });
       });
       it('should not have tradable components for Sagek Prime', async () => {
@@ -217,7 +217,7 @@ const test = (base) => {
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
 
         matches[0].components.forEach(comp => {
-          assert(!comp.tradable)
+          assert.strictEqual(comp.tradable, false);
         });
       });
       it('should have 4 tradable components for Boar Prime', async () => {
@@ -230,13 +230,13 @@ const test = (base) => {
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
 
-        var tradable = 0;
+        let tradable = 0;
         matches[0].components.forEach(comp => {
-          if (comp.tradable) {
+          if (comp.tradable === true) {
             tradable++
           }
         });
-        assert(tradable === 4);
+        assert.strictEqual(tradable, 4);
       });
       it('should have Primed Continuity as tradable', async () => {
         const matches = data.mods
@@ -247,7 +247,7 @@ const test = (base) => {
           });
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
-        assert(matches[0].tradable);
+        assert.strictEqual(matches[0].tradable, true);
       }); 
       it('weapons should only have 1 result for Mausolon', () => {
         const matches = data.weapons
@@ -269,7 +269,7 @@ const test = (base) => {
           });
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
-        assert(!matches[0].tradable);
+        assert.strictEqual(matches[0].tradable, false);
       });
       it('warframes should only have 1 result for Octavia Prime', () => {
         const matches = data.warframes

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -192,6 +192,63 @@ const test = (base) => {
     });
     describe('integrity', async () => {
       beforeEach(gc);
+      it('should not have tradable components for Galariak Prime', async () => {
+        const matches = data.weapons
+          .filter((i) => i.name === 'Galariak Prime')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+
+        matches[0].components.forEach(comp => {
+          assert(!comp.tradable)
+        });
+      });
+      it('should not have tradable components for Sagek Prime', async () => {
+        const matches = data.weapons
+          .filter((i) => i.name === 'Sagek Prime')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+
+        matches[0].components.forEach(comp => {
+          assert(!comp.tradable)
+        });
+      });
+      it('should have 4 tradable components for Boar Prime', async () => {
+        const matches = data.weapons
+          .filter((i) => i.name === 'Boar Prime')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+
+        var tradable = 0;
+        matches[0].components.forEach(comp => {
+          if (comp.tradable) {
+            tradable++
+          }
+        });
+        assert(tradable === 4);
+      });
+      it('should have Primed Continuity as tradable', async () => {
+        const matches = data.mods
+          .filter((i) => i.name === 'Primed Continuity')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert(matches[0].tradable);
+      }); 
       it('weapons should only have 1 result for Mausolon', () => {
         const matches = data.weapons
           .filter((i) => i.name === 'Mausolon')
@@ -202,6 +259,17 @@ const test = (base) => {
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
         assert.strictEqual(matches.length, 1, 'There can be only One');
+      });
+      it('warframe Octavia Prime should be untradable', () => {
+        const matches = data.warframes
+          .filter((i) => i.name === 'Octavia Prime')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert(!matches[0].tradable);
       });
       it('warframes should only have 1 result for Octavia Prime', () => {
         const matches = data.warframes


### PR DESCRIPTION
resolves  #975 

### Reproduction steps
<!--
View the melee and secondary json.
-->

---

### Evidence/screenshot/link to line

Changes made in tradable.ts and parser.js

### Considerations
- Does this contain a new dependency? No
- Does this introduce opinionated data formatting or manual data entry? No
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? No
- Have I run the linter? YES
- Is is a bug fix, feature request, or enhancement? Bug Fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements
* Improved drop-rate information for parent-qualified blueprints and refined relics.
* Improved trade eligibility checks for Prime items using available drop sources.

## Bug Fixes
* Corrected handling of standalone blueprints without a parent item.
* Updated trade classifications for Sentinel, Archwing, Arch-Gun, Arch-Melee, and Pet items.
* Added support for trading Arch-Gun Mods where applicable.
* Prevented built Prime items from being incorrectly marked as tradable.
* Improved accuracy for Prime weapon, mod, and Warframe trade status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->