### PR TITLE
docs(readme): file structure section .mjs -> .ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ to get you started.
 ### File structure
 All relevant scripts are found in `/build/` with
 
-[build.mjs](/build/build.mjs)<br>
+[build.ts](/build/build.ts)<br>
 The entrypoint for the build script. Here we also save JSON, image and cache data.
 
-[scraper.mjs](/build/scraper.mjs)<br>
+[scraper.ts](/build/scraper.ts)<br>
 Fetches all external data and returns it to the parser.
 
-[parser.mjs](/build/parser.mjs)<br>
+[parser.ts](/build/parser.ts)<br>
 Parses the external data to match our schema and returns it to the build script.
 
 <br>


### PR DESCRIPTION
### What did you fix? 
closes #977
Updates the links in README.md's File structure section from .mjs to .ts.

---

### Reproduction steps

1. Visit README at: https://github.com/WFCD/warframe-items?tab=readme-ov-file#file-structure
1. Click build.mjs
1. Result: 404

---

### Evidence/screenshot/link to line

You can see my fix on lines 130, 133, and 136 of README.md.

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Docs]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the developer file-structure documentation to reference the current TypeScript build, scraper, and parser entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->