### PR TITLE
fix(typings): add Zaw Amp Kitgun tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ coverage
 .jshintrc
 .env
 .eslintcache
+
+# It's too large now
+data/json/All.json

--- a/build/parser.ts
+++ b/build/parser.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import cloneDeep from 'lodash.clonedeep';
 import sanitize from 'sanitize-filename';
 
@@ -36,7 +39,10 @@ import type {
   ExaltedSlot,
 } from './types/shared';
 
-const previousBuild = await readJson<ItemComplete[]>(new URL('../data/json/All.json', import.meta.url));
+const previousBuildUrl = new URL('../data/json/All.json', import.meta.url);
+const previousBuild = existsSync(fileURLToPath(previousBuildUrl))
+  ? await readJson<ItemComplete[]>(previousBuildUrl)
+  : [];
 const watson = await readJson<Record<string, string>>(new URL('../config/dt_map.json', import.meta.url));
 const bpConflicts = await readJson<string[]>(new URL('../config/bpConflicts.json', import.meta.url));
 const variants = await readJson<VariantsConfig>(new URL('../config/variants.json', import.meta.url));

--- a/index.d.ts
+++ b/index.d.ts
@@ -754,6 +754,7 @@ declare module '@wfcd/items' {
   type ShotType = 'Continuous' | 'Hit-Scan' | 'Projectile';
 
   type Tag =
+    | 'Amp'
     | 'Arbiters of Hexis'
     | 'Baro'
     | 'Cephalon'
@@ -769,6 +770,7 @@ declare module '@wfcd/items' {
     | 'Incarnon'
     | 'Infested'
     | 'Invasion Reward'
+    | 'Kitgun'
     | 'Kuva Lich'
     | 'Lua'
     | 'Never Vaulted'
@@ -792,7 +794,8 @@ declare module '@wfcd/items' {
     | 'Vandal'
     | 'Vaulted'
     | 'Wraith'
-    | 'Zariman';
+    | 'Zariman'
+    | 'Zaw';
 
   type Trigger = 'Active' | 'Auto' | 'Auto Burst' | 'Burst' | 'Charge' | 'Duplex' | 'Held' | 'Melee' | 'Semi' | '';
 

--- a/test/build.integrity.spec.mjs
+++ b/test/build.integrity.spec.mjs
@@ -2,9 +2,12 @@ import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 
+import Items from '../index.mjs';
+
 const require = createRequire(import.meta.url);
 
-const all = require('../data/json/All.json');
+// All.json is gitignored; compose from per-category dumps via Items
+const all = new Items();
 const arcanes = require('../data/json/Arcanes.json');
 const warnings = JSON.parse(readFileSync(new URL('../data/warnings.json', import.meta.url), 'utf8'));
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
fix typings blocking PRs

---

### Reproduction steps
run builds on PR

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `Amp`, `Kitgun`, and `Zaw` item tags in the public type definitions.

- **Bug Fixes**
  - Builds now complete successfully when the optional full item data file is unavailable.

- **Tests**
  - Updated build validation to verify complete item data using the available category data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->