### PR TITLE
fix(parser): map damagePerShot puncture/slash in DE order

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -37,6 +37,7 @@ import type {
   Resistance,
   ApiCategory,
   ExaltedSlot,
+  Damage,
 } from './types/shared';
 
 const previousBuildUrl = new URL('../data/json/All.json', import.meta.url);
@@ -55,6 +56,7 @@ const overrides = await readJson<Record<string, Partial<ItemComplete>>>(
 const masterableCategories = await readJson<MasterableCategories>(
   new URL('../config/masterableCategories.json', import.meta.url)
 );
+const damageTypes = await readJson<(keyof Damage)[]>(new URL('../config/damageTypes.json', import.meta.url));
 
 const productCategoryTypeMap: Record<string, string> = {
   SpaceGuns: 'Arch-Gun',
@@ -545,51 +547,11 @@ class Parser {
   addDamage(item: ItemComplete): void {
     if (!item.damagePerShot) return;
     if (!item.damagePerShot.find((damageType) => damageType > 0)) return;
-    const [
-      impact,
-      slash,
-      puncture,
-      heat,
-      cold,
-      electricity,
-      toxin,
-      blast,
-      radiation,
-      gas,
-      magnetic,
-      viral,
-      corrosive,
-      voidDamage,
-      tau,
-      cinematic,
-      shieldDrain,
-      healthDrain,
-      energyDrain,
-      trueType,
-    ] = item.damagePerShot;
-    item.damage = {
-      total: item.totalDamage,
-      impact,
-      puncture,
-      slash,
-      heat,
-      cold,
-      electricity,
-      toxin,
-      blast,
-      radiation,
-      gas,
-      magnetic,
-      viral,
-      corrosive,
-      void: voidDamage,
-      tau,
-      cinematic,
-      shieldDrain,
-      healthDrain,
-      energyDrain,
-      true: trueType,
-    };
+    const damage: Damage = { total: item.totalDamage };
+    damageTypes.forEach((type, i) => {
+      damage[type] = item.damagePerShot![i];
+    });
+    item.damage = damage;
   }
 
   /**

--- a/config/damageTypes.json
+++ b/config/damageTypes.json
@@ -1,16 +1,22 @@
 [
   "impact",
-  "slash",
   "puncture",
+  "slash",
   "heat",
   "cold",
   "electricity",
   "toxin",
+  "blast",
+  "radiation",
+  "gas",
+  "magnetic",
   "viral",
   "corrosive",
-  "radiation",
-  "blast",
-  "magnetic",
-  "gas",
-  "void"
+  "void",
+  "tau",
+  "cinematic",
+  "shieldDrain",
+  "healthDrain",
+  "energyDrain",
+  "true"
 ]

--- a/test/parser.damage.spec.mjs
+++ b/test/parser.damage.spec.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert';
+
+import parser from '../build/parser';
+import { buildRaw } from './fixtures/wikia.fixture.mjs';
+
+const findItem = (parsed, name) => parsed.data.flatMap((c) => c.data).find((i) => i.name === name);
+
+/**
+ * Public Export `damagePerShot` values, taken from WFCD/warframe-items#973.
+ * Physical indices are Impact, Puncture, Slash.
+ */
+const weapons = [
+  {
+    name: 'Miter',
+    uniqueName: '/Lotus/Weapons/Tenno/LongGuns/Miter/Miter',
+    damagePerShot: [12.5, 12.5, 225],
+    dominant: 'slash',
+  },
+  {
+    name: 'Dread',
+    uniqueName: '/Lotus/Weapons/Tenno/Bows/DreadBow/DreadBow',
+    damagePerShot: [16.800001, 16.800001, 302.39999],
+    dominant: 'slash',
+  },
+  {
+    name: 'Paris Prime',
+    uniqueName: '/Lotus/Weapons/Tenno/Bows/PrimeParisBow/PrimeParisBow',
+    damagePerShot: [9, 288, 63.000004],
+    dominant: 'puncture',
+  },
+  {
+    name: 'Boltor',
+    uniqueName: '/Lotus/Weapons/Tenno/Rifle/BoltoRifle/BoltoRifle',
+    damagePerShot: [2.5, 20, 2.499999],
+    dominant: 'puncture',
+  },
+];
+
+const parseWeapon = ({ name, uniqueName, damagePerShot }) => {
+  const parsed = parser.parse(
+    buildRaw({
+      api: [
+        {
+          category: 'Weapons',
+          data: [
+            {
+              name,
+              uniqueName,
+              slot: 1,
+              damagePerShot,
+              totalDamage: damagePerShot.reduce((sum, value) => sum + value, 0),
+            },
+          ],
+        },
+      ],
+    })
+  );
+
+  return findItem(parsed, name)?.damage;
+};
+
+describe('addDamage', () => {
+  weapons.forEach((weapon) => {
+    it(`should map ${weapon.name} damage as primarily ${weapon.dominant}`, () => {
+      const damage = parseWeapon(weapon);
+      assert(damage, `${weapon.name} should have damage`);
+
+      const [impact, puncture, slash] = weapon.damagePerShot;
+      assert.strictEqual(damage.impact, impact);
+      assert.strictEqual(damage.puncture, puncture);
+      assert.strictEqual(damage.slash, slash);
+
+      const highest = ['impact', 'puncture', 'slash'].reduce((a, b) => (damage[a] > damage[b] ? a : b));
+      assert.strictEqual(highest, weapon.dominant, `${weapon.name} should be primarily ${weapon.dominant}`);
+    });
+  });
+
+  it('should map elemental damage after the physical types', () => {
+    const damage = parseWeapon({
+      name: 'Ignis',
+      uniqueName: '/Lotus/Weapons/Tenno/LongGuns/Flamethrower/Flamethrower',
+      damagePerShot: [0, 0, 0, 35],
+    });
+
+    assert.strictEqual(damage.heat, 35);
+    assert.strictEqual(damage.cold, undefined);
+  });
+
+  it('should not add damage when every type is zero', () => {
+    const damage = parseWeapon({
+      name: 'Zero Weapon',
+      uniqueName: '/Lotus/Weapons/Tenno/LongGuns/Zero/Zero',
+      damagePerShot: [0, 0, 0],
+    });
+
+    assert.strictEqual(damage, undefined);
+  });
+});


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Closes #973

---

### Reproduction steps
N/A

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional damage types, including tau, cinematic, shield drain, health drain, energy drain, and true damage.
  - Damage information now reflects the expanded set of available damage categories.

- **Bug Fixes**
  - Corrected damage type ordering and mapping so physical and elemental damage values appear in the appropriate fields.
  - Improved handling of items with no damage values, preventing empty damage data from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->