### PR TITLE
fix: scraper for necramech, wiki exception Dark Split-Sword

### DIFF
--- a/build/parser.ts
+++ b/build/parser.ts
@@ -884,6 +884,9 @@ class Parser {
     if (type === 'Exalted Weapon' || type === 'Kitgun Component') {
       return { wikiCategory: 'weapons', handler: 'weapon' };
     }
+    if (type === 'Necramech') {
+      return { wikiCategory: 'necramechs', handler: 'warframe' };
+    }
 
     switch (item.category) {
       case 'Arcanes':

--- a/build/scraper.ts
+++ b/build/scraper.ts
@@ -16,7 +16,7 @@ import VersionScraper from './wikia/scrapers/VersionScraper';
 import readJson from './readJson';
 import sleep from './sleep';
 import { get, getJSON, retryAttempts } from './network';
-import type { WikiaData, WikiaWarframe } from './types/shared';
+import type { WikiaData } from './types/shared';
 import type { TitaniaRelic } from '@wfcd/relics';
 import type { Patchlogs } from '@wfcd/patchlogs';
 
@@ -291,6 +291,7 @@ class Scraper {
     await sleep(100);
     const warframes = await new WarframeScraper().scrape();
     bar.tick();
+    await sleep(100);
     const necramechs = await new NecramechScraper().scrape();
     bar.tick();
     await sleep(100);
@@ -312,29 +313,10 @@ class Scraper {
     const vaultData = await new VaultScraper().scrape();
     bar.tick();
 
-    // Combine scraped warframe and necramech data to keep
-    // current data format (mechs and frames are 1 thing)
-    // for compatibility reasons
-    necramechs.forEach((mech) => {
-      const mechToFrame: WikiaWarframe = {
-        name: mech.name,
-        uniqueName: mech.uniqueName,
-        url: mech.url,
-        conclave: mech.conclave,
-        mr: mech.mr,
-        polarities: mech.polarities,
-        sprint: mech.sprint,
-        introduced: mech.introduced,
-        vaulted: mech.vaulted,
-        thumbnail: mech.thumbnail,
-        marketCost: mech.marketCost,
-      };
-      warframes.push(mechToFrame);
-    });
-
     return {
       weapons,
       warframes,
+      necramechs,
       mods,
       versions,
       ducats,

--- a/build/scraper.ts
+++ b/build/scraper.ts
@@ -10,12 +10,13 @@ import CompanionScraper from './wikia/scrapers/CompanionScraper';
 import ModScraper from './wikia/scrapers/ModScraper';
 import WeaponScraper from './wikia/scrapers/WeaponScraper';
 import WarframeScraper from './wikia/scrapers/WarframeScraper';
+import NecramechScraper from './wikia/scrapers/NecramechScraper';
 import VaultScraper from './wikia/scrapers/VaultScraper';
 import VersionScraper from './wikia/scrapers/VersionScraper';
 import readJson from './readJson';
 import sleep from './sleep';
 import { get, getJSON, retryAttempts } from './network';
-import type { WikiaData } from './types/shared';
+import type { WikiaData, WikiaWarframe } from './types/shared';
 import type { TitaniaRelic } from '@wfcd/relics';
 import type { Patchlogs } from '@wfcd/patchlogs';
 
@@ -290,6 +291,8 @@ class Scraper {
     await sleep(100);
     const warframes = await new WarframeScraper().scrape();
     bar.tick();
+    const necramechs = await new NecramechScraper().scrape();
+    bar.tick();
     await sleep(100);
     const mods = await new ModScraper().scrape();
     bar.tick();
@@ -308,6 +311,14 @@ class Scraper {
     await sleep(100);
     const vaultData = await new VaultScraper().scrape();
     bar.tick();
+
+    // Combine scraped warframe and necramech data to keep 
+    // current data format (mechs and frames are 1 thing)
+    // for compatibility reasons
+    necramechs.forEach(mech => {
+      const mechToFrame = mech as WikiaWarframe
+      warframes.push(mechToFrame)
+    });
 
     return {
       weapons,

--- a/build/scraper.ts
+++ b/build/scraper.ts
@@ -272,7 +272,7 @@ class Scraper {
    * @returns wikia data
    */
   async fetchWikiaData(): Promise<WikiaData> {
-    const bar = new Progress('Fetching Wikia Data', 9);
+    const bar = new Progress('Fetching Wikia Data', 10);
     const ducats: WikiaDucat[] = [];
     const ducatsWikia = await get('https://wiki.warframe.com/w/Ducats/Prices/All', true);
     const $ = load(ducatsWikia as string);

--- a/build/scraper.ts
+++ b/build/scraper.ts
@@ -312,12 +312,24 @@ class Scraper {
     const vaultData = await new VaultScraper().scrape();
     bar.tick();
 
-    // Combine scraped warframe and necramech data to keep 
+    // Combine scraped warframe and necramech data to keep
     // current data format (mechs and frames are 1 thing)
     // for compatibility reasons
-    necramechs.forEach(mech => {
-      const mechToFrame = mech as WikiaWarframe
-      warframes.push(mechToFrame)
+    necramechs.forEach((mech) => {
+      const mechToFrame: WikiaWarframe = {
+        name: mech.name,
+        uniqueName: mech.uniqueName,
+        url: mech.url,
+        conclave: mech.conclave,
+        mr: mech.mr,
+        polarities: mech.polarities,
+        sprint: mech.sprint,
+        introduced: mech.introduced,
+        vaulted: mech.vaulted,
+        thumbnail: mech.thumbnail,
+        marketCost: mech.marketCost,
+      };
+      warframes.push(mechToFrame);
     });
 
     return {

--- a/build/scraper.ts
+++ b/build/scraper.ts
@@ -21,8 +21,30 @@ import type { TitaniaRelic } from '@wfcd/relics';
 import type { Patchlogs } from '@wfcd/patchlogs';
 
 const locales = await readJson<string[]>(new URL('../config/locales.json', import.meta.url));
+const wikiaNameOverrides = await readJson<WikiaNameOverride[]>(new URL('../config/wikiaNameOverrides.json', import.meta.url));
 
 const prod = process.env.NODE_ENV === 'production';
+
+interface WikiaNameOverride {
+  name: string;
+  override: string;
+}
+
+/**
+ * Check for and apply overrides for WikiaData names
+ * @param wikiaData - set of WikiaData to check
+ */
+const applyNameOverrides = (wikiaData: WikiaData) => {
+  const overrideMap: Record<string, string> = Object.fromEntries(
+    wikiaNameOverrides.map((override) => [override.name, override.override])
+  );
+  for (const key of Object.keys(wikiaData) as (keyof WikiaData)[]) {
+    for (const entry of wikiaData[key]) {
+      const replacement = overrideMap[entry.name];
+      if (replacement) entry.name = replacement;
+    }
+  }
+};
 
 interface ApiChunk {
   category: string;
@@ -313,7 +335,7 @@ class Scraper {
     const vaultData = await new VaultScraper().scrape();
     bar.tick();
 
-    return {
+    const wikiaToReturn: WikiaData = {
       weapons,
       warframes,
       necramechs,
@@ -325,6 +347,9 @@ class Scraper {
       arcanes,
       vaultData,
     };
+
+    applyNameOverrides(wikiaToReturn);
+    return wikiaToReturn;
   }
 
   /**

--- a/build/types/shared.ts
+++ b/build/types/shared.ts
@@ -93,6 +93,7 @@ export type Locales = Record<string, Record<string, unknown>>;
 export interface WikiaData {
   weapons: WikiaWeapon[];
   warframes: WikiaWarframe[];
+  necramechs: WikiaNecramech[];
   mods: WikiaMod[];
   versions: WikiaVersion[];
   ducats: WikiaDucat[];

--- a/build/types/shared.ts
+++ b/build/types/shared.ts
@@ -143,6 +143,18 @@ export interface WikiaWarframe {
   bpCost?: number;
   [key: string]: unknown;
 }
+export interface WikiaNecramech {
+  name: string;
+  uniqueName?: string;
+  url: string;
+  mr?: number;
+  polarities?: string[];
+  sprint?: number;
+  introduced?: string;
+  vaulted?: boolean;
+  thumbnail?: string;
+  [key: string]: unknown;
+}
 
 export interface WikiaMod {
   name: string;

--- a/build/types/shared.ts
+++ b/build/types/shared.ts
@@ -143,16 +143,19 @@ export interface WikiaWarframe {
   bpCost?: number;
   [key: string]: unknown;
 }
+
 export interface WikiaNecramech {
   name: string;
   uniqueName?: string;
   url: string;
+  conclave?: number;
   mr?: number;
   polarities?: string[];
   sprint?: number;
   introduced?: string;
   vaulted?: boolean;
   thumbnail?: string;
+  marketCost?: number;
   [key: string]: unknown;
 }
 

--- a/build/wikia/scrapers/NecramechScraper.ts
+++ b/build/wikia/scrapers/NecramechScraper.ts
@@ -1,0 +1,9 @@
+import WikiaDataScraper from '../WikiaDataScraper';
+import transformNecramech from '../transformers/transformNecramech';
+import type { WikiaNecramech } from '../../types/shared';
+
+export default class NecramechScraper extends WikiaDataScraper<WikiaNecramech> {
+  constructor() {
+    super('https://wiki.warframe.com/w/Module:Warframes/data?action=edit', 'Necramech', transformNecramech);
+  }
+}

--- a/build/wikia/transformers/transformNecramech.ts
+++ b/build/wikia/transformers/transformNecramech.ts
@@ -1,0 +1,52 @@
+import transformPolarity from './transformPolarity';
+import type { WikiaNecramech } from '../../types/shared';
+
+interface OldNecramech {
+  Name?: string;
+  Image?: string;
+  Mastery?: number;
+  Polarities?: string[];
+  Sprint?: number;
+  Introduced?: string;
+  Vaulted?: boolean;
+  InternalName?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Transform wikia lua necramechs into usable standardized json
+ * @param oldMech - old necramech in lua format
+ * @param imageUrls - name-url pairs
+ * @returns transformed necramech data
+ */
+export default (
+  oldMechs: OldNecramech,
+  imageUrls: Record<string, string>,
+  _blueprints?: Record<string, unknown>
+): WikiaNecramech | undefined => {
+  let newMechs: WikiaNecramech | undefined;
+  if (!oldMechs.Name) {
+    throw new Error('Missing necramech Name');
+  }
+
+  try {
+    const { Image, Mastery, Polarities, Sprint, Introduced, Vaulted, InternalName, Name } = oldMechs;
+
+    newMechs = {
+      name: Name,
+      uniqueName: InternalName,
+      url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
+      mr: Mastery ?? 0,
+      polarities: Polarities,
+      sprint: Sprint,
+      introduced: Introduced,
+      vaulted: Vaulted ?? undefined,
+      thumbnail: imageUrls[Image ?? ''],
+    };
+    newMechs = transformPolarity(oldMechs, newMechs);
+  } catch (error) {
+    console.error(`Error parsing ${oldMechs.Name}`);
+    throw error;
+  }
+  return newMechs;
+};

--- a/build/wikia/transformers/transformNecramech.ts
+++ b/build/wikia/transformers/transformNecramech.ts
@@ -1,9 +1,10 @@
 import transformPolarity from './transformPolarity';
-import type { WikiaNecramech } from '../../types/shared';
+import type { WikiaNecramech, Blueprint } from '../../types/shared';
 
 interface OldNecramech {
   Name?: string;
   Image?: string;
+  Conclave?: number;
   Mastery?: number;
   Polarities?: string[];
   Sprint?: number;
@@ -17,36 +18,43 @@ interface OldNecramech {
  * Transform wikia lua necramechs into usable standardized json
  * @param oldMech - old necramech in lua format
  * @param imageUrls - name-url pairs
+ * @param blueprints - blueprint objects
  * @returns transformed necramech data
  */
 export default (
-  oldMechs: OldNecramech,
+  oldMech: OldNecramech,
   imageUrls: Record<string, string>,
-  _blueprints?: Record<string, unknown>
+  blueprints: Record<string, unknown>
 ): WikiaNecramech | undefined => {
-  let newMechs: WikiaNecramech | undefined;
-  if (!oldMechs.Name) {
+  let newMech: WikiaNecramech | undefined;
+  if (!oldMech.Name) {
     throw new Error('Missing necramech Name');
   }
 
   try {
-    const { Image, Mastery, Polarities, Sprint, Introduced, Vaulted, InternalName, Name } = oldMechs;
+    const { Name, Conclave, Image, Mastery, Polarities, Sprint, Introduced, Vaulted, InternalName }
+      = oldMech;
 
-    newMechs = {
+    newMech = {
       name: Name,
       uniqueName: InternalName,
       url: `https://wiki.warframe.com/w/${encodeURIComponent(Name.replace(/\s/g, '_'))}`,
+      conclave: Conclave,
       mr: Mastery ?? 0,
       polarities: Polarities,
       sprint: Sprint,
       introduced: Introduced,
       vaulted: Vaulted ?? undefined,
       thumbnail: imageUrls[Image ?? ''],
+      marketCost:
+        blueprints[Name] && typeof (blueprints[Name] as Blueprint).MarketCost === 'number'
+          ? ((blueprints[Name] as Blueprint).MarketCost as number)
+          : undefined,
     };
-    newMechs = transformPolarity(oldMechs, newMechs);
+    newMech = transformPolarity(oldMech, newMech);
   } catch (error) {
-    console.error(`Error parsing ${oldMechs.Name}`);
+    console.error(`Error parsing ${oldMech.Name}`);
     throw error;
   }
-  return newMechs;
+  return newMech;
 };

--- a/build/wikia/transformers/transformWeapon.ts
+++ b/build/wikia/transformers/transformWeapon.ts
@@ -198,17 +198,17 @@ const parseSlam = ({
 
 /**
  * Convert some odd weapon naming conventions
- * @param ToConvert - weapon to fix 
+ * @param ToConvert - weapon to fix
  * @return weapon with naming fixed
 */
 const fixNamingConvention = (NameToConvert: string): string => {
-  if (NameToConvert === "Dark Split-Sword (Heavy Blade)") {
-    // only converting 1 of these to avoid the parser.ts name wikia 
+  if (NameToConvert === 'Dark Split-Sword (Heavy Blade)') {
+    // only converting 1 of these to avoid the parser.ts name wikia
     // ambiguity check, since both names can go go to the same url.
-    return "Dark Split-Sword"
+    return 'Dark Split-Sword';
   }
-  return NameToConvert
-}
+  return NameToConvert;
+};
 
 /**
  * Parse raw weapon data to a clean weapon object

--- a/build/wikia/transformers/transformWeapon.ts
+++ b/build/wikia/transformers/transformWeapon.ts
@@ -197,6 +197,20 @@ const parseSlam = ({
 };
 
 /**
+ * Convert some odd weapon naming conventions
+ * @param ToConvert - weapon to fix 
+ * @return weapon with naming fixed
+*/
+const fixNamingConvention = (NameToConvert: string): string => {
+  if (NameToConvert === "Dark Split-Sword (Heavy Blade)") {
+    // only converting 1 of these to avoid the parser.ts name wikia 
+    // ambiguity check, since both names can go go to the same url.
+    return "Dark Split-Sword"
+  }
+  return NameToConvert
+}
+
+/**
  * Parse raw weapon data to a clean weapon object
  * @param oldWeapon - raw weapon data
  * @param imageUrls - image urls
@@ -213,6 +227,7 @@ export default async (
   if (!oldWeapon.Name) {
     return undefined;
   }
+  oldWeapon.Name = fixNamingConvention(oldWeapon.Name);
   try {
     const {
       Mastery,

--- a/build/wikia/transformers/transformWeapon.ts
+++ b/build/wikia/transformers/transformWeapon.ts
@@ -197,20 +197,6 @@ const parseSlam = ({
 };
 
 /**
- * Convert some odd weapon naming conventions
- * @param ToConvert - weapon to fix
- * @return weapon with naming fixed
-*/
-const fixNamingConvention = (NameToConvert: string): string => {
-  if (NameToConvert === 'Dark Split-Sword (Heavy Blade)') {
-    // only converting 1 of these to avoid the parser.ts name wikia
-    // ambiguity check, since both names can go go to the same url.
-    return 'Dark Split-Sword';
-  }
-  return NameToConvert;
-};
-
-/**
  * Parse raw weapon data to a clean weapon object
  * @param oldWeapon - raw weapon data
  * @param imageUrls - image urls
@@ -227,7 +213,6 @@ export default async (
   if (!oldWeapon.Name) {
     return undefined;
   }
-  oldWeapon.Name = fixNamingConvention(oldWeapon.Name);
   try {
     const {
       Mastery,

--- a/config/itemTypes.json
+++ b/config/itemTypes.json
@@ -64,6 +64,10 @@
     "name": "Arch-Gun"
   },
   {
+    "id": "/EntratiMech/",
+    "name": "Necramech"
+  },
+  {
     "id": "Powersuits/.*Augment",
     "regex": true,
     "name": "Warframe Mod"

--- a/config/wikiaNameOverrides.json
+++ b/config/wikiaNameOverrides.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Dark Split-Sword (Heavy Blade)",
+    "override": "Dark Split-Sword"
+  }
+]

--- a/index.d.ts
+++ b/index.d.ts
@@ -851,6 +851,7 @@ declare module '@wfcd/items' {
       | 'Mission Rewards'
       | 'Mod Locations'
       | 'Mod Set Mod'
+      | 'Necramech'
       | 'Nightwave Challenge'
       | 'Node'
       | 'Note Packs'

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -201,6 +201,7 @@ const test = (base) => {
           });
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert.strictEqual(matches.length, 1);
 
         assert.strictEqual(matches[0].wikiAvailable, true)        
       });
@@ -213,6 +214,7 @@ const test = (base) => {
           });
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert.strictEqual(matches.length, 1);
 
         assert.strictEqual(matches[0].wikiAvailable, true)        
       });
@@ -225,6 +227,7 @@ const test = (base) => {
           });
         const dd = dedupe(matches);
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+        assert.strictEqual(matches.length, 1);
 
         assert.strictEqual(matches[0].wikiAvailable, true)        
       });

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -192,6 +192,42 @@ const test = (base) => {
     });
     describe('integrity', async () => {
       beforeEach(gc);
+      it('should have wikia available for Dark Split-Sword', async () => {
+        const matches = data.weapons
+          .filter((i) => i.name === 'Dark Split-Sword')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+
+        assert.strictEqual(matches[0].wikiAvailable, true)        
+      });
+      it('should only have wikia available for Voidrig', async () => {
+        const matches = data.warframes
+          .filter((i) => i.name === 'Voidrig')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+
+        assert.strictEqual(matches[0].wikiAvailable, true)        
+      });
+      it('should only have wikia available for Bonewidow', async () => {
+        const matches = data.warframes
+          .filter((i) => i.name === 'Bonewidow')
+          .map((i) => {
+            delete i.patchlogs;
+            return i;
+          });
+        const dd = dedupe(matches);
+        assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
+
+        assert.strictEqual(matches[0].wikiAvailable, true)        
+      });
       it('should not have tradable components for Galariak Prime', async () => {
         const matches = data.weapons
           .filter((i) => i.name === 'Galariak Prime')

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -203,7 +203,7 @@ const test = (base) => {
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
         assert.strictEqual(matches.length, 1);
 
-        assert.strictEqual(matches[0].wikiAvailable, true)        
+        assert.strictEqual(matches[0].wikiAvailable, true);
       });
       it('should only have wikia available for Voidrig', async () => {
         const matches = data.warframes
@@ -216,7 +216,7 @@ const test = (base) => {
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
         assert.strictEqual(matches.length, 1);
 
-        assert.strictEqual(matches[0].wikiAvailable, true)        
+        assert.strictEqual(matches[0].wikiAvailable, true);
       });
       it('should only have wikia available for Bonewidow', async () => {
         const matches = data.warframes
@@ -229,7 +229,7 @@ const test = (base) => {
         assert.strictEqual(dd.length, matches.length, 'Before and after dedupe should match');
         assert.strictEqual(matches.length, 1);
 
-        assert.strictEqual(matches[0].wikiAvailable, true)        
+        assert.strictEqual(matches[0].wikiAvailable, true);
       });
       it('should not have tradable components for Galariak Prime', async () => {
         const matches = data.weapons


### PR DESCRIPTION
### What did you fix?
closes #968 

---

### Reproduction steps
<!--
Warframe.json "Voidrig" and "Bonewidow" entries do not have wikia data
Melee.json "Dark Split-Sword' does not have wikia data
-->

---

### Evidence/screenshot/link to line
See new necramech scraper and changes made in 
transformWeapon.ts [204-210 and [230]

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Necramech collection with metadata, images, wiki links, configuration details, and market values.
  * Added support for Voidrig and Bonewidow entries.

* **Bug Fixes**
  * Corrected the displayed name for Dark Split-Sword (Heavy Blade) to “Dark Split-Sword.”
  * Improved data validation so Dark Split-Sword, Voidrig, and Bonewidow are correctly recognized as available on the wiki.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->